### PR TITLE
Add ONVIF metadata stream component.

### DIFF
--- a/lib/components/index.browser.js
+++ b/lib/components/index.browser.js
@@ -2,6 +2,7 @@ const AACDepay = require('./aacdepay')
 const BasicDepay = require('./basicdepay')
 const H264Depay = require('./h264depay')
 const JpegDepay = require('./jpegdepay')
+const OnvifDepay = require('./onvifdepay')
 const Inspector = require('./inspector')
 const Mp4Capture = require('./mp4capture')
 const Mp4Muxer = require('./mp4muxer')
@@ -17,6 +18,7 @@ module.exports = {
   BasicDepay,
   H264Depay,
   JpegDepay,
+  OnvifDepay,
   Inspector,
   Mp4Capture,
   Mp4Muxer,

--- a/lib/components/index.node.js
+++ b/lib/components/index.node.js
@@ -3,6 +3,7 @@ const Auth = require('./auth')
 const BasicDepay = require('./basicdepay')
 const H264Depay = require('./h264depay')
 const JpegDepay = require('./jpegdepay')
+const OnvifDepay = require('./onvifdepay')
 const Inspector = require('./inspector')
 const Mp4Capture = require('./mp4capture')
 const Mp4Muxer = require('./mp4muxer')
@@ -19,6 +20,7 @@ module.exports = {
   BasicDepay,
   H264Depay,
   JpegDepay,
+  OnvifDepay,
   Inspector,
   Mp4Capture,
   Mp4Muxer,

--- a/lib/components/onvifdepay/index.js
+++ b/lib/components/onvifdepay/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./onvifdepay-component')

--- a/lib/components/onvifdepay/onvifdepay-component.js
+++ b/lib/components/onvifdepay/onvifdepay-component.js
@@ -1,0 +1,64 @@
+const {Transform} = require('stream')
+const {Rtp} = require('../../utils/protocols')
+const {SDP, RTP, XML} = require('../messageTypes')
+const Component = require('../component')
+
+class ONVIFDepayComponent extends Component {
+  constructor (handler) {
+    let payloadType
+    let packets = []
+
+    const incoming = new Transform({
+      objectMode: true,
+      transform (msg, encoding, callback) {
+        if (msg.type === SDP) {
+          const xmlMedia = msg.sdp.media.find(media => {
+            return (
+              media.type === 'application' &&
+              media.rtpmap &&
+              media.rtpmap.encodingName === 'VND.ONVIF.METADATA'
+            )
+          })
+          if (xmlMedia) {
+            payloadType = Number(xmlMedia.rtpmap.payloadType)
+          }
+          callback(null, msg)
+        } else if (msg.type === RTP && Rtp.payloadType(msg.data) === payloadType) {
+          // Add payload to packet stack
+          packets.push(Rtp.payload(msg.data))
+
+          // XML over RTP uses the RTP marker bit to indicate end
+          // of fragmentation. At this point, the packets can be used
+          // to reconstruct an XML packet.
+          if (Rtp.marker(msg.data) && packets.length > 0) {
+            const xmlMsg = {
+              timestamp: Rtp.timestamp(msg.data),
+              ntpTimestamp: msg.ntpTimestamp,
+              payloadType: Rtp.payloadType(msg.data),
+              data: Buffer.concat(packets),
+              type: XML
+            }
+            // If there is a handler, the XML message will leave
+            // through the handler, otherwise send it on to the
+            // next component
+            if (handler) {
+              handler(xmlMsg)
+            } else {
+              this.push(xmlMsg)
+            }
+            packets = []
+          }
+          callback()
+        } else {
+          // Not a message we should handle
+          callback(null, msg)
+        }
+      }
+    })
+
+    // outgoing will be defaulted to a PassThrough stream
+    super(incoming)
+  }
+}
+
+module.exports = ONVIFDepayComponent

--- a/lib/components/onvifdepay/onvifdepay-component.test.js
+++ b/lib/components/onvifdepay/onvifdepay-component.test.js
@@ -1,0 +1,9 @@
+const validateComponent = require('../../utils/validate-component')
+const OnvifDepayComponent = require('./')
+
+describe('ONVIF depay component', () => {
+  describe('is a valid component', () => {
+    const c = new OnvifDepayComponent()
+    validateComponent(c, 'ONVIF depay component')
+  })
+})

--- a/lib/pipelines/html5-video-metadata-pipeline.js
+++ b/lib/pipelines/html5-video-metadata-pipeline.js
@@ -1,0 +1,21 @@
+const Html5VideoPipeline = require('./html5-video-pipeline')
+
+const OnvifDepay = require('../components/onvifdepay')
+
+class Html5VideoMetadataPipeline extends Html5VideoPipeline {
+  /**
+   * Create a pipeline which is a linked list of components.
+   * Works naturally with only a single component.
+   * @param {Array} components The ordered components of the pipeline
+   */
+  constructor (config = {}) {
+    const { metadataHandler } = config
+
+    super(config)
+
+    const onvifDepay = new OnvifDepay(metadataHandler)
+    this.insertAfter(this.session, onvifDepay)
+  }
+}
+
+module.exports = Html5VideoMetadataPipeline

--- a/lib/pipelines/index.browser.js
+++ b/lib/pipelines/index.browser.js
@@ -5,6 +5,7 @@ const RtspMp4Pipeline = require('./rtsp-mp4-pipeline')
 const Html5CanvasPipeline = require('./html5-canvas-pipeline')
 const Html5VideoPipeline = require('./html5-video-pipeline')
 const Html5VideoXmlPipeline = require('./html5-video-xml-pipeline')
+const Html5VideoMetadataPipeline = require('./html5-video-metadata-pipeline')
 
 // Legacy "static" pipelines
 const WebSocketRtspSdp = require('./websocket-rtsp-sdp')
@@ -20,6 +21,7 @@ module.exports = {
   Html5CanvasPipeline,
   Html5VideoPipeline,
   Html5VideoXmlPipeline,
+  Html5VideoMetadataPipeline,
   WebSocketRtspSdp,
   WebSocketRtspVideo,
   WebSocketRtspVideoXml,


### PR DESCRIPTION
ONVIF metadata is sent as XML data over RTP.
This PR adds a component that can parse such
packets and optionally pass them to a separate
handler instead of pushing them on the incoming stream.