### PR TITLE
Replace shorthand method names.

### DIFF
--- a/lib/components/aacdepay/aacdepay-component.js
+++ b/lib/components/aacdepay/aacdepay-component.js
@@ -49,7 +49,7 @@ class AACDepayComponent extends Component {
 
     const incoming = new Transform({
       objectMode: true,
-      transform (msg, encoding, callback) {
+      transform: function (msg, encoding, callback) {
         if (msg.type === SDP) {
           // Check if there is an AAC track in the SDP
           const validMedia = msg.sdp.media.find(media => {

--- a/lib/components/auth/auth-component.js
+++ b/lib/components/auth/auth-component.js
@@ -24,7 +24,7 @@ class AuthComponent extends Component {
     let lastSentMessage, authHeader
     const outgoing = new Transform({
       objectMode: true,
-      transform (msg, encoding, callback) {
+      transform: function (msg, encoding, callback) {
         if (msg.type === RTSP) {
           lastSentMessage = msg
           if (authHeader) {
@@ -38,7 +38,7 @@ class AuthComponent extends Component {
 
     const incoming = new Transform({
       objectMode: true,
-      transform (msg, encoding, callback) {
+      transform: function (msg, encoding, callback) {
         if (msg.type === RTSP && Rtsp.statusCode(msg.data) === UNAUTHORIZED) {
           authHeader = 'Basic ' + Buffer.from(username + ':' + password).toString('base64')
           const headers = msg.data.toString().split('\n')

--- a/lib/components/basicdepay/basicdepay-component.js
+++ b/lib/components/basicdepay/basicdepay-component.js
@@ -13,7 +13,7 @@ class BasicDepayComponent extends Component {
 
     const incoming = new Transform({
       objectMode: true,
-      transform (msg, encoding, callback) {
+      transform: function (msg, encoding, callback) {
         if (msg.type === RTP && Rtp.payloadType(msg.data) === payloadType) {
           const payload = Rtp.payload(msg.data)
           buffer = Buffer.concat([buffer, payload])

--- a/lib/components/h264depay/h264depay-component.js
+++ b/lib/components/h264depay/h264depay-component.js
@@ -15,7 +15,7 @@ class H264DepayComponent extends Component {
 
     const incoming = new Transform({
       objectMode: true,
-      transform (msg, encoding, callback) {
+      transform: function (msg, encoding, callback) {
         // Get correct payload types from sdp to identify video and audio
         if (msg.type === SDP) {
           msg.sdp.media.forEach(media => {

--- a/lib/components/helpers/stream-factory.js
+++ b/lib/components/helpers/stream-factory.js
@@ -11,7 +11,7 @@ class StreamFactory {
   static consumer (fn = () => {}) {
     return new stream.Writable({
       objectMode: true,
-      write (msg, encoding, callback) {
+      write: function (msg, encoding, callback) {
         fn(msg)
         callback()
       }
@@ -26,7 +26,7 @@ class StreamFactory {
     let counter = 0
     return new stream.Readable({
       objectMode: true,
-      read () {
+      read: function () {
         if (messages !== undefined && counter < messages.length) {
           this.push(messages[counter++])
         }
@@ -37,7 +37,7 @@ class StreamFactory {
   static recorder (type, fileStream) {
     return new stream.Transform({
       objectMode: true,
-      transform (msg, encoding, callback) {
+      transform: function (msg, encoding, callback) {
         const timestamp = Date.now()
         // Replace binary data with base64 string
         const message = Object.assign({}, msg, {data: msg.data.toString('base64')})
@@ -57,7 +57,7 @@ class StreamFactory {
     let lastTimestamp = packets[0].timestamp
     return new stream.Readable({
       objectMode: true,
-      read () {
+      read: function () {
         const packet = packets[packetCounter++]
         if (packet) {
           const {type, timestamp, message} = packet

--- a/lib/components/inspector/inspector-component.js
+++ b/lib/components/inspector/inspector-component.js
@@ -32,7 +32,7 @@ class InspectorComponent extends Component {
 
     const incoming = new Transform({
       objectMode: true,
-      transform (msg, encoding, callback) {
+      transform: function (msg, encoding, callback) {
         incomingLogger(msg)
         callback(null, msg)
       }
@@ -42,7 +42,7 @@ class InspectorComponent extends Component {
 
     const outgoing = new Transform({
       objectMode: true,
-      transform (msg, encoding, callback) {
+      transform: function (msg, encoding, callback) {
         outgoingLogger(msg)
         callback(null, msg)
       }

--- a/lib/components/mp4muxer/mp4muxer-component.js
+++ b/lib/components/mp4muxer/mp4muxer-component.js
@@ -22,7 +22,7 @@ class Mp4MuxerComponent extends Component {
     const boxBuilder = new BoxBuilder()
     const incoming = new Transform({
       objectMode: true,
-      transform (msg, encoding, callback) {
+      transform: function (msg, encoding, callback) {
         if (msg.type === SDP) {
           /**
            * Arrival of SDP signals the beginning of a new movie.

--- a/lib/components/mse/mse-component.js
+++ b/lib/components/mse/mse-component.js
@@ -100,7 +100,7 @@ class MseComponent extends Component {
      */
     const outgoing = new Readable({
       objectMode: true,
-      read () {
+      read: function () {
         //
       }
     })

--- a/lib/components/replayer/replayer-component.js
+++ b/lib/components/replayer/replayer-component.js
@@ -23,7 +23,7 @@ class ReplayerComponent extends Component {
 
     const incoming = new Readable({
       objectMode: true,
-      read () {
+      read: function () {
         //
       }
     })
@@ -48,7 +48,7 @@ class ReplayerComponent extends Component {
 
     const outgoing = new Writable({
       objectMode: true,
-      write (msg, encoding, callback) {
+      write: function (msg, encoding, callback) {
         start() // resume streaming
         callback()
       }

--- a/lib/components/rtsp-parser/rtspparser-component.js
+++ b/lib/components/rtsp-parser/rtspparser-component.js
@@ -23,7 +23,7 @@ class RtspParserComponent extends Component {
     // Incoming stream
     const incoming = new Transform({
       objectMode: true,
-      transform (msg, encoding, callback) {
+      transform: function (msg, encoding, callback) {
         if (msg.type === RAW) {
           parser.parse(msg.data).forEach((message) => incoming.push(message))
           callback()

--- a/lib/components/tcp/tcp-component.js
+++ b/lib/components/tcp/tcp-component.js
@@ -17,7 +17,7 @@ class TcpComponent extends Component {
      */
     const incoming = new Readable({
       objectMode: true,
-      read () {
+      read: function () {
         //
       }
     })
@@ -34,7 +34,7 @@ class TcpComponent extends Component {
      */
     const outgoing = new Writable({
       objectMode: true,
-      write (msg, encoding, callback) {
+      write: function (msg, encoding, callback) {
         const b = msg.data
 
         if (!socket) {

--- a/lib/components/websocket/websocket-component.js
+++ b/lib/components/websocket/websocket-component.js
@@ -28,7 +28,7 @@ class WebSocketComponent extends Component {
      */
     const incoming = new Readable({
       objectMode: true,
-      read () {
+      read: function () {
         //
       }
     })
@@ -59,7 +59,7 @@ class WebSocketComponent extends Component {
      */
     const outgoing = new Writable({
       objectMode: true,
-      write (msg, encoding, callback) {
+      write: function (msg, encoding, callback) {
         try {
           socket.send(msg.data)
         } catch (e) {

--- a/lib/components/xml-parser/xmlparser-component.js
+++ b/lib/components/xml-parser/xmlparser-component.js
@@ -22,7 +22,7 @@ class XmlParserComponent extends Component {
      */
     const incoming = new Transform({
       objectMode: true,
-      transform (msg, encoding, callback) {
+      transform: function (msg, encoding, callback) {
         if (msg.type === ELEMENTARY && msg.payloadType === payloadType) {
           msg.type = XML
           msg.doc = xmlParser.parseFromString(msg.data.toString(), 'text/xml')


### PR DESCRIPTION
To work around an issue with Edge, where the use
of shorthand method names together with using the
super keyword fails (Microsoft/ChakraCore/issues/5030)

Fixes #27