### PR TITLE
Do not access trackData if undefined.

### DIFF
--- a/lib/components/mp4muxer/mp4muxer-component.js
+++ b/lib/components/mp4muxer/mp4muxer-component.js
@@ -86,11 +86,11 @@ class Mp4MuxerComponent extends Component {
   }
 
   get bitrate () {
-    return this.boxBuilder.trackData.map((data) => data.bitrate)
+    return this.boxBuilder.trackData && this.boxBuilder.trackData.map((data) => data.bitrate)
   }
 
   get framerate () {
-    return this.boxBuilder.trackData.map((data) => data.framerate)
+    return this.boxBuilder.trackData && this.boxBuilder.trackData.map((data) => data.framerate)
   }
 
   get ntpPresentationTime () {


### PR DESCRIPTION
If there is no trackData yet, do not try to map
to either bitrate or framerate.

Fixes #39