### PR TITLE
Run rtsp-ws-server in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ node_modules/
 # Cypress
 cypress/videos/
 cypress/screenshots/
+
+#Intellij
+.idea/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '3.0'
 services:
+
   rtsp-proxy:
     build:
       context: ./
@@ -7,3 +8,18 @@ services:
     image: gaetancollaud/rtsp-ws-server
     ports:
       - 8854:8854
+    links:
+      - rtsp-h264
+      - rtsp-motion
+
+  rtsp-h264:
+    image: steabert/gst-rtsp-launch
+    command: ["videotestsrc ! video/x-raw,width=1920,height=1080 ! timeoverlay text='H.264' valignment=top halignment=left ! x264enc ! rtph264pay name=pay0 pt=96"]
+    ports:
+      - 8554:8554
+
+  rtsp-motion:
+    image: steabert/gst-rtsp-launch
+    command: ["videotestsrc pattern=ball ! video/x-raw,width=1280,height=720 ! timeoverlay text='MJPEG' valignment=top halignment=left ! jpegenc ! rtpjpegpay name=pay0 pt=96"]
+    ports:
+      - 8555:8554

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.0'
+services:
+  rtsp-proxy:
+    build:
+      context: ./
+      dockerfile: ./rtsp-ws-server/Dockerfile
+    image: gaetancollaud/rtsp-ws-server
+    ports:
+      - 8854:8854

--- a/rtsp-ws-server/Dockerfile
+++ b/rtsp-ws-server/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:10
+WORKDIR /node-build
+ADD package.json yarn.lock  ./
+RUN yarn install
+
+FROM node:10-alpine
+WORKDIR /app
+COPY --from=0 /node-build ./
+COPY lib lib
+COPY rtsp-ws-server rtsp-ws-server
+CMD ["node", "/app/rtsp-ws-server/tcp-ws-proxy.js"]


### PR DESCRIPTION
This pull request add build information for the rtsp-ws-server. You can then use it in the pipelines line this:
```js
{
    ws: {uri: `ws://yourDockerHost:8854`},
    rtsp: {uri: `rtsp://yourRtspStreamUrl`},
```

If you want to use the test stream you can do it like this:
```js
{
    ws: {uri: `ws://localhost:8854`},
    rtsp: {uri: `rtsp://rtsp-h264:8554`},
```
If you want I can continue by putting the dev server in docker as well, so we can run all examples in one command. What do you think ?

Also for the test pages, I didn't change the urls because I didn't want to force the usage of docker, but we can imagine having two buttons, one to start playing using local urls (like it is now) and one for using docker urls. Let me know.