### PR TITLE
Publish dist/ folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,9 +4,6 @@
 # Coverage directory (tests with coverage)
 coverage/
 
-# Bundles
-dist/
-
 # Dependencies
 node_modules/
 


### PR DESCRIPTION
This change resolves issue #67.

I just added a `.npmignore` file with the exact same definition as `.gitignore` except for the `dist/` folder.

Don't forget to `yarn build` before publishing. It can be added as `prepublish` task if you want ?

And I added the ignore for the intellij folder as well.


