### PR TITLE
Feature/publish dist folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ node_modules/
 # Cypress
 cypress/videos/
 cypress/screenshots/
+
+ #Intellij
+.idea/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+# Logs
+*.log
+
+# Coverage directory (tests with coverage)
+coverage/
+
+# Dependencies
+node_modules/
+
+# Cypress
+cypress/videos/
+cypress/screenshots/

--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,6 @@ node_modules/
 # Cypress
 cypress/videos/
 cypress/screenshots/
+
+ #Intellij
+.idea/


### PR DESCRIPTION
This change resolves issue #67 and fixes issue in pull request #73.

I just added a `.npmignore` file with the exact same definition as `.gitignore` except for the `dist/` folder.

Don't forget to `yarn build` before publishing. It can be added as `prepublish` task if you want ?

And I added the ignore for the intellij folder as well.

Just to be sure I tried to publish on https://www.npmjs.com/package/gaetancollaud-media-stream-library and it works. ;)