### PR TITLE
Fix the Node CLI example.

### DIFF
--- a/examples/node/player.js
+++ b/examples/node/player.js
@@ -53,4 +53,4 @@ const config = { rtsp: {
 
 // Setup a new pipeline
 const pipeline = new pipelines.TcpRtspMp4Pipeline(config)
-pipeline.play()
+pipeline.rtsp.play()

--- a/lib/pipelines/tcp-rtsp-mp4-pipeline.js
+++ b/lib/pipelines/tcp-rtsp-mp4-pipeline.js
@@ -18,7 +18,7 @@ class CliMp4Pipeline extends RtspMp4Pipeline {
     super(rtspConfig)
 
     const auth = new Authorization(authConfig)
-    this.insertBefore(this.session, auth)
+    this.insertBefore(this.rtsp, auth)
 
     const tcpSource = new TcpSource(tcpConfig)
 


### PR DESCRIPTION
The Node CLI example now uses the correct API after
the changes introduced in 148c2ac.