### PR TITLE
Guard against RTP timestamp wrap for NTP timestamp.

### DIFF
--- a/lib/components/rtsp-session/rtspsession-component.js
+++ b/lib/components/rtsp-session/rtspsession-component.js
@@ -196,7 +196,11 @@ class RtspSessionComponent extends Component {
     if (typeof t0 !== 'undefined' && typeof n0 !== 'undefined') {
       const clockrate = this.clockrates[rtpChannel]
       const t = Rtp.timestamp(msg.data)
-      msg.ntpTimestamp = ((t - t0) / clockrate) * 1000 + n0
+      // The RTP timestamps are unsigned 32 bit and will overflow
+      // at some point. We can guard against the overflow by ORing with 0,
+      // which will bring any difference back into signed 32-bit domain.
+      const dt = (t - t0) | 0
+      msg.ntpTimestamp = (dt / clockrate) * 1000 + n0
     }
   }
 


### PR DESCRIPTION
The RTP timestamp can wrap around, so that the difference
between the timestamps needs to account for the possibility
that one of them has wrapped.