### PR TITLE
Add auth support for streaming RTSP over WS

### DIFF
--- a/lib/components/auth/auth-component.js
+++ b/lib/components/auth/auth-component.js
@@ -44,7 +44,7 @@ class AuthComponent extends Component {
           const headers = msg.data.toString().split('\n')
           const wwwAuth = headers.find((header) => header.match('WWW-Auth'))
           const authenticator = wwwAuthenticate(username, password)(wwwAuth)
-          authHeader = authenticator.authorize(lastSentMessage.method, '/axis-media/media.amp')
+          authHeader = authenticator.authorize(lastSentMessage.method, lastSentMessage.uri)
 
           // Retry last RTSP message
           // Write will fire our outgoing transform function.

--- a/lib/pipelines/html5-video-pipeline.js
+++ b/lib/pipelines/html5-video-pipeline.js
@@ -2,6 +2,7 @@ const RtspMp4Pipeline = require('./rtsp-mp4-pipeline')
 
 const WebSocketSrc = require('../components/websocket')
 const MseSink = require('../components/mse')
+const Authorization = require('../components/auth')
 
 /**
  * Pipeline that can receive H264/AAC video over RTP
@@ -17,9 +18,14 @@ class Html5VideoPipeline extends RtspMp4Pipeline {
    * @memberof Html5VideoPipeline
    */
   constructor (config = {}) {
-    const { ws: wsConfig, rtsp: rtspConfig, mediaElement } = config
+    const { ws: wsConfig, rtsp: rtspConfig, mediaElement, auth: authConfig } = config
 
     super(rtspConfig)
+
+    if (authConfig) {
+      const auth = new Authorization(authConfig)
+      this.insertBefore(this.rtsp, auth)
+    }
 
     const mseSink = new MseSink(mediaElement)
     mseSink.onSourceOpen = (mse, tracks) => {


### PR DESCRIPTION
This PR adds support for authentication when streaming RTSP over websockets as I don't think it was possible for (at least for generic cameras). Essentially, it copies the pattern used by `CliMp4Pipeline` to  the class `Html5VideoPipeline` - allowing authentication params to be passed to in the config as in the following format:

```javascript
  Pipeline = pipelines.Html5VideoPipeline
  const pipeline = new Pipeline({
    ws: { uri: `ws://localhost:8854` },
    rtsp: { uri: `rtspurl` },
    auth: { username: 'admin', password: 'mypassword' },
    mediaElement
  })
```
I tested out this change by updating the simple-player.js example to supply the username and password and streaming from a (non-Axis) camera.

As part of doing this change, I noticed that there was a hard-coded string in auth-component.js that meant that it would only work for Axis cameras. This was used as the URI for the digest for authentication. I've replaced it with the URI of the last message which I think will be more generally correct.

Assuming these changes are acceptable I think it would probably be good to have an example or documentation of the appropriate config. As mentioned I modified the simple-player.js example and I wonder whether it would be good to have this more generic. I assume that the authentication method I added would work in place of the current authentication mechanism in simple-player.js but, as I can't verify this myself, it would be good to get some feedback before updating the example. 

I believe this change address #99.

Cheers,
Simon
