### PR TITLE
Replace www-authenticate with custom md5.js auth.

### DIFF
--- a/lib/components/auth/digest.test.ts
+++ b/lib/components/auth/digest.test.ts
@@ -1,0 +1,19 @@
+import { authHeaders, credentials, request, cnonce } from './fixtures'
+import { DigestAuth } from './digest'
+import { parseWWWAuthenticate } from './www-authenticate'
+const header = authHeaders['WWW-Authenticate']
+
+describe('digest challenge', () => {
+  it('generates the correct authentication header', () => {
+    const challenge = parseWWWAuthenticate(header)
+    const digest = new DigestAuth(
+      challenge.params,
+      credentials.username,
+      credentials.password,
+    )
+    // overwrite the cnonce function
+    digest.cnonce = () => cnonce
+    const authHeader = digest.authorization(request.method, request.uri)
+    expect(authHeader).toEqual(authHeaders.Authorization)
+  })
+})

--- a/lib/components/auth/digest.ts
+++ b/lib/components/auth/digest.ts
@@ -1,0 +1,123 @@
+// https://tools.ietf.org/html/rfc2617#section-3.2.1
+
+import MD5 from 'md5.js'
+import { ChallengeParams } from './www-authenticate'
+
+export class DigestAuth {
+  private realm: string
+  private nonce: string
+  private opaque?: string
+  private algorithm?: 'md5' | 'md5-sess'
+  private qop?: 'auth' | 'auth-int'
+  private username: string
+
+  private ha1Base: string
+  private count: number
+
+  constructor(params: ChallengeParams, username: string, password: string) {
+    const realm = params.get('realm')
+    if (realm === undefined) {
+      throw new Error('no realm in digest challenge')
+    }
+    this.realm = realm
+    this.ha1Base = new MD5()
+      .update(`${username}:${realm}:${password}`)
+      .digest('hex')
+
+    const nonce = params.get('nonce')
+    if (nonce === undefined) {
+      throw new Error('no nonce in digest challenge')
+    }
+    this.nonce = nonce
+
+    this.opaque = params.get('opaque')
+
+    const algorithm = params.get('algorithm')
+    if (algorithm !== undefined) {
+      if (algorithm === 'md5') {
+        this.algorithm = 'md5'
+      } else if (algorithm === 'md5-sess') {
+        this.algorithm = 'md5-sess'
+      }
+    }
+
+    const qop = params.get('qop')
+    if (qop !== undefined) {
+      const possibleQops = qop.split(',').map(qopType => qopType.trim())
+      if (possibleQops.some(qopValue => qopValue === 'auth')) {
+        this.qop = 'auth'
+      } else if (possibleQops.some(qopValue => qopValue === 'auth-int')) {
+        this.qop = 'auth-int'
+      }
+    }
+
+    this.count = 0
+    this.username = username
+  }
+
+  nc = () => {
+    ++this.count
+    return this.count.toString(16).padStart(8, '0')
+  }
+
+  cnonce = () => {
+    return new Array(4)
+      .fill(0)
+      .map(() => Math.floor(Math.random() * 256))
+      .map(n => n.toString(16))
+      .join('')
+  }
+
+  ha1 = (cnonce: string): string => {
+    let ha1 = this.ha1Base
+    if (this.algorithm === 'md5-sess') {
+      ha1 = new MD5().update(`${ha1}:${this.nonce}:${cnonce}`).digest('hex')
+    }
+    return ha1
+  }
+
+  ha2 = (method: string, uri: string, body: string = ''): string => {
+    let ha2 = new MD5().update(`${method}:${uri}`).digest('hex')
+    if (this.algorithm === 'md5-sess') {
+      const hbody = new MD5().update(body).digest('hex')
+      ha2 = new MD5().update(`${method}:${uri}:${hbody}`).digest('hex')
+    }
+    return ha2
+  }
+
+  authorization = (
+    method: string = 'GET',
+    uri: string = '',
+    body?: string,
+  ): string => {
+    // Increase count
+    const nc = this.nc()
+    const cnonce = this.cnonce()
+
+    const ha1 = this.ha1(cnonce)
+    const ha2 = this.ha2(method, uri, body)
+
+    const response =
+      this.qop === undefined
+        ? new MD5().update(`${ha1}:${this.nonce}:${ha2}`).digest('hex')
+        : new MD5()
+            .update(`${ha1}:${this.nonce}:${nc}:${cnonce}:${this.qop}:${ha2}`)
+            .digest('hex')
+
+    const authorizationParams = []
+    authorizationParams.push(`username="${this.username}"`)
+    authorizationParams.push(`realm="${this.realm}"`)
+    authorizationParams.push(`nonce="${this.nonce}"`)
+    authorizationParams.push(`uri="${uri}"`)
+    if (this.qop !== undefined) {
+      authorizationParams.push(`qop=${this.qop}`)
+      authorizationParams.push(`nc=${nc}`)
+      authorizationParams.push(`cnonce="${cnonce}"`)
+    }
+    authorizationParams.push(`response="${response}"`)
+    if (this.opaque !== undefined) {
+      authorizationParams.push(`opaque="${this.opaque}"`)
+    }
+    return `Digest ${authorizationParams.join(', ')}`
+  }
+}

--- a/lib/components/auth/fixtures.ts
+++ b/lib/components/auth/fixtures.ts
@@ -1,0 +1,28 @@
+export const credentials = {
+  username: 'Mufasa',
+  password: 'Circle Of Life',
+}
+
+export const request = {
+  method: 'GET',
+  uri: '/dir/index.html',
+}
+
+export const cnonce = '0a4f113b'
+
+export const authHeaders = {
+  'WWW-Authenticate':
+    'Digest realm="testrealm@host.com", \
+qop="auth,auth-int", \
+nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", \
+opaque="5ccc069c403ebaf9f0171e9517f40e41"',
+  Authorization:
+    'Digest username="Mufasa", realm="testrealm@host.com", \
+nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", \
+uri="/dir/index.html", \
+qop=auth, \
+nc=00000001, \
+cnonce="0a4f113b", \
+response="6629fae49393a05397450978507c4ef1", \
+opaque="5ccc069c403ebaf9f0171e9517f40e41"',
+}

--- a/lib/components/auth/md5.d.ts
+++ b/lib/components/auth/md5.d.ts
@@ -1,0 +1,1 @@
+declare module 'md5.js'

--- a/lib/components/auth/www-authenticate.ts
+++ b/lib/components/auth/www-authenticate.ts
@@ -1,0 +1,25 @@
+export type ChallengeParams = Map<string, string>
+
+export interface Challenge {
+  type: string
+  params: ChallengeParams
+}
+
+export const parseWWWAuthenticate = (header: string): Challenge => {
+  const [type, ...challenge] = header.split(' ')
+
+  const pairs: [string, string][] = []
+  const re = /\s*([^=]+)=\"([^\"]*)\",?/gm
+  let match
+  do {
+    match = re.exec(challenge.join(''))
+    if (match !== null) {
+      const [full, key, value] = match
+      pairs.push([key, value.toLowerCase()])
+    }
+  } while (match !== null)
+
+  const params = new Map(pairs)
+
+  return { type: type.toLowerCase(), params }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "main": "dist/cjs/index.node.js",
   "browser": "dist/esm/index.browser.js",
+  "browserslist": "last 2 versions, not dead",
   "module": "dist/esm/index.node.js",
   "bin": {
     "live": "examples/node/player.js"
@@ -34,7 +35,6 @@
   "dependencies": {
     "debug": "^4.0.0",
     "ws": "^6.0.0",
-    "www-authenticate": "^0.6.2",
     "yargs": "^13.2.1"
   },
   "devDependencies": {
@@ -51,6 +51,7 @@
     "cypress": "3.1.5",
     "http-server": "0.11.1",
     "jest": "24.1.0",
+    "md5.js": "^1.3.5",
     "mock-socket": "8.0.5",
     "prettier": "1.16.4",
     "ts-jest": "24.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4030,7 +4030,7 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-md5.js@^1.3.4:
+md5.js@^1.3.4, md5.js@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
   integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
@@ -6311,11 +6311,6 @@ ws@^6.0.0:
   integrity sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==
   dependencies:
     async-limiter "~1.0.0"
-
-www-authenticate@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/www-authenticate/-/www-authenticate-0.6.2.tgz#b7a7d487bdc5a8b423a4d8fd5f9c661adde50ebf"
-  integrity sha1-t6fUh73FqLQjpNj9X5xmGt3lDr8=
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Because of the large overhead of using Node's crypto
library, replace www-authenticate with a custom auth
implementation for Basic and Digest auth, based on the
md5.js library.