### PR TITLE
WebSocket Server external use

### DIFF
--- a/lib/pipelines/tcp-ws-proxy-pipeline.ts
+++ b/lib/pipelines/tcp-ws-proxy-pipeline.ts
@@ -4,6 +4,8 @@ import { WSSink } from '../components/ws-sink'
 import { TcpSource } from '../components/tcp'
 
 export class TcpWsProxyPipeline extends Pipeline {
+  public wss: Server
+
   constructor(config = {}) {
     const wss = new Server(config)
     wss.on('connection', socket => {
@@ -14,5 +16,8 @@ export class TcpWsProxyPipeline extends Pipeline {
     })
 
     super()
+
+    // Expose WebSocket Server for external use
+    this.wss = wss
   }
 }


### PR DESCRIPTION
Sometimes you want to create websocket socket without server instance, and attach server later or handle WS upgrades somewhere in the application. 

For example: 
```
const proxy = new pipelines.TcpWsProxyPipeline( { noServer : true });
server.on('upgrade', (request, socket, head) => {
  const path = url.parse(request.url).pathname;
  if (path === '/ws-tcp-proxy') {
    proxy.wss.handleUpgrade(request, socket, head, (ws) => {
      proxy.wss.emit('connection', ws, request);
    });
  }
});
```