### PR TITLE
fix: initialize ONVIF packets array

### DIFF
--- a/lib/components/onvifdepay/index.ts
+++ b/lib/components/onvifdepay/index.ts
@@ -11,7 +11,7 @@ import {
 export class ONVIFDepay extends Tube {
   constructor(handler: (msg: XmlMessage) => void) {
     let XMLPayloadType: number
-    let packets: Buffer[]
+    let packets: Buffer[] = []
 
     const incoming = new Transform({
       objectMode: true,


### PR DESCRIPTION
The packets array was previously not initialized causing an error when trying
to push a value to undefined

Change-Id: If5eac9672477f896f0fb209cdbb02422d27cdd66