### PR TITLE
fix(metadata)!: MetadataPipeline stops working after a while

### DIFF
--- a/examples/browser/camera/simple-metadata-player.js
+++ b/examples/browser/camera/simple-metadata-player.js
@@ -1,0 +1,68 @@
+const { pipelines } = window.mediaStreamLibrary
+
+// force auth
+const authorize = async host => {
+  // Force a login by fetching usergroup
+  const fetchOptions = {
+    credentials: 'include',
+    headers: {
+      'Axis-Orig-Sw': true,
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+    mode: 'no-cors',
+  }
+  try {
+    await window.fetch(`http://${host}/axis-cgi/usergroup.cgi`, fetchOptions)
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+const play = host => {
+  const initialTime = window.performance.now()
+  // Setup a new pipeline
+  const pipeline = new pipelines.MetadataPipeline({
+    ws: {
+      uri: `ws://${host}/rtsp-over-websocket`,
+      tokenUri: `http://${host}/axis-cgi/rtspwssession.cgi`,
+      protocol: 'binary',
+      timeout: 10000,
+    },
+    rtsp: {
+      uri: `rtsp://${host}/axis-media/media.amp?event=on&video=0&audio=0`,
+    },
+    metadataHandler: msg => {
+      const title = document.createElement('div')
+      title.textContent = `+${window.performance.now() - initialTime}`
+      title.classList.add('metadata-title')
+
+      const content = document.createElement('div')
+      content.textContent = new TextDecoder().decode(msg.data)
+      content.classList.add('metadata-content')
+
+      document.querySelector('#placeholder').prepend(title, content)
+    },
+  })
+  pipeline.ready.then(() => {
+    pipeline.rtsp.play()
+  })
+
+  return pipeline
+}
+
+let pipeline
+
+// Each time a device ip is entered, authorize and then play
+const playButton = document.querySelector('#play')
+playButton.addEventListener('click', async e => {
+  pipeline && pipeline.close()
+
+  const device = document.querySelector('#device')
+  const host = device.value || device.placeholder
+
+  console.log(host)
+
+  await authorize(host)
+
+  pipeline = play(host)
+})

--- a/examples/browser/camera/simple-metadata.html
+++ b/examples/browser/camera/simple-metadata.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example metadata streaming from Axis camera</title>
+  </head>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    .metadata-title {
+      margin-bottom: 5px;
+      font-weight: bold;
+    }
+
+    .metadata-content {
+      margin-bottom: 20px;
+      font-family: monospace;
+      font-size: 80%;
+    }
+
+    .metadata-container {
+      height: 400px;
+      width: 100%;
+      border: 1px solid black;
+      padding: 10px;
+      margin: 10px 0;
+      overflow: hidden auto;
+    }
+  </style>
+  <body>
+    <div>
+      <div>
+        <label for="device">Device IP:</label>
+        <input id="device" type="text" placeholder="192.168.0.90" />
+      </div>
+      <button id="play">Play</button>
+    </div>
+    <div class="metadata-container" id="placeholder" />
+    <script src="../media-stream-library.min.js"></script>
+    <script src="simple-metadata-player.js"></script>
+  </body>
+</html>

--- a/lib/components/component.ts
+++ b/lib/components/component.ts
@@ -157,8 +157,8 @@ export class Source extends AbstractComponent {
 
 export class Tube extends Source {
   public static fromHandlers(
-    fnIncoming: MessageHandler,
-    fnOutgoing: MessageHandler,
+    fnIncoming: MessageHandler | undefined,
+    fnOutgoing: MessageHandler | undefined,
   ) {
     const incomingStream = fnIncoming
       ? StreamFactory.peeker(fnIncoming)

--- a/lib/components/onvifdepay/index.test.ts
+++ b/lib/components/onvifdepay/index.test.ts
@@ -3,9 +3,7 @@ import { runComponentTests } from '../../utils/validate-component'
 
 describe('ONVIF depay component', () => {
   describe('is a valid component', () => {
-    const c = new ONVIFDepay(() => {
-      /** noop */
-    })
+    const c = new ONVIFDepay()
     runComponentTests(c, 'ONVIF depay component')
   })
 })

--- a/lib/components/onvifdepay/index.ts
+++ b/lib/components/onvifdepay/index.ts
@@ -9,7 +9,7 @@ import {
 } from '../../utils/protocols/rtp'
 
 export class ONVIFDepay extends Tube {
-  constructor(handler?: (msg: XmlMessage) => void) {
+  constructor() {
     let XMLPayloadType: number
     let packets: Buffer[] = []
 
@@ -49,15 +49,9 @@ export class ONVIFDepay extends Tube {
               data: Buffer.concat(packets),
               type: MessageType.XML,
             }
-            // If there is a handler, the XML message will leave
-            // through the handler, otherwise send it on to the
-            // next component
-            if (handler) {
-              handler(xmlMsg)
-            } else {
-              this.push(xmlMsg)
-            }
+            callback(undefined, xmlMsg)
             packets = []
+            return
           }
           callback()
         } else {

--- a/lib/pipelines/html5-video-metadata-pipeline.ts
+++ b/lib/pipelines/html5-video-metadata-pipeline.ts
@@ -1,6 +1,7 @@
 import { Html5VideoPipeline, Html5VideoConfig } from './html5-video-pipeline'
 import { ONVIFDepay } from '../components/onvifdepay'
-import { XmlMessage } from '../components/message'
+import { XmlMessage, MessageType } from '../components/message'
+import { Tube } from '../components/component'
 
 export interface Html5VideoMetadataConfig extends Html5VideoConfig {
   metadataHandler: (msg: XmlMessage) => void
@@ -18,7 +19,14 @@ export class Html5VideoMetadataPipeline extends Html5VideoPipeline {
 
     super(config)
 
-    const onvifDepay = new ONVIFDepay(metadataHandler)
+    const onvifDepay = new ONVIFDepay()
     this.insertAfter(this.rtsp, onvifDepay)
+
+    const onvifHandlerPipe = Tube.fromHandlers(msg => {
+      if (msg.type === MessageType.XML) {
+        metadataHandler(msg as XmlMessage)
+      }
+    }, undefined)
+    this.insertAfter(onvifDepay, onvifHandlerPipe)
   }
 }

--- a/lib/pipelines/metadata-pipeline.ts
+++ b/lib/pipelines/metadata-pipeline.ts
@@ -3,7 +3,8 @@ import { ONVIFDepay } from '../components/onvifdepay'
 import { WSSource } from '../components/ws-source'
 import { WSConfig } from '../components/ws-source/openwebsocket'
 import { RtspConfig } from '../components/rtsp-session'
-import { XmlMessage } from '../components/message'
+import { XmlMessage, MessageType } from '../components/message'
+import { Sink } from '../components/component'
 
 // Default configuration for XML event stream
 const DEFAULT_RTSP_PARAMETERS = {
@@ -31,8 +32,14 @@ export class MetadataPipeline extends RtspPipeline {
 
     super(Object.assign({}, DEFAULT_RTSP_PARAMETERS, rtspConfig))
 
-    const onvifDepay = new ONVIFDepay(metadataHandler)
+    const onvifDepay = new ONVIFDepay()
     this.append(onvifDepay)
+    const handlerSink = Sink.fromHandler(msg => {
+      if (msg.type === MessageType.XML) {
+        metadataHandler(msg as XmlMessage)
+      }
+    })
+    this.append(handlerSink)
 
     const waitForWs = WSSource.open(wsConfig)
     this.ready = waitForWs.then(wsSource => {


### PR DESCRIPTION
- Remove the `ONVIFDepay` handler. Instead this tube now only depays
  the XML messages (as it did before). To handle the messages either
  add a separate pipe to your pipeline after the Onvif one, or end
  your pipeline with a sink where you can handle the messages.

- The `MetadataPipeline` now adds a handler sink at the end of the
  pipeline that calls the metadata handler. This fixes a bug where
  the pipeline would stall after `ONVIFDepay` would push messages
  to a non-existing next pipe or sink.

- Add a new browser example on how to use the `MetadataPipeline`.