### PR TITLE
Do not close TcpSource socket on inactivity

### DIFF
--- a/lib/components/tcp/index.ts
+++ b/lib/components/tcp/index.ts
@@ -52,11 +52,6 @@ export class TcpSource extends Source {
             socket.destroy()
             incoming.push(null)
           })
-          socket.setTimeout(2000, () => {
-            console.error(`Timeout when connecting to ${hostname}:${port}`)
-            socket.destroy()
-            incoming.push(null)
-          })
 
           socket.on('data', (buffer) => {
             if (!incoming.push({ data: buffer, type: MessageType.RAW })) {


### PR DESCRIPTION
Remove timeout that closes the socket of TcpSource after a 2s inactivity. This will allow us to have the stream open even though no events are published from the device.

Closes #400