### PR TITLE
Move md5.js to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   ],
   "dependencies": {
     "debug": "4.1.1",
+    "md5.js": "1.3.5",
     "ws": "7.2.5"
   },
   "devDependencies": {
@@ -66,7 +67,6 @@
     "eslint-plugin-promise": "4.2.1",
     "http-server": "0.12.3",
     "jest": "25.5.4",
-    "md5.js": "1.3.5",
     "mock-socket": "9.0.3",
     "prettier": "2.0.5",
     "ts-jest": "25.4.0",


### PR DESCRIPTION
The dependency `md5.js` is noted in `devDependencies`, but it is actually a production dependency since it is referenced from the class `DigestAuth`.

Closes #396