### PR TITLE
Let TcpSource subscribe to the correct event

### DIFF
--- a/lib/components/tcp/index.ts
+++ b/lib/components/tcp/index.ts
@@ -62,8 +62,8 @@ export class TcpSource extends Source {
           })
           // When closing a socket, indicate there is no more data to be sent,
           // but leave the outgoing stream open to check if more requests are coming.
-          socket.on('finish', (e) => {
-            console.warn('socket finished', e)
+          socket.on('end', () => {
+            console.warn('socket ended')
             incoming.push(null)
           })
         }


### PR DESCRIPTION
We're subscribing to the `socket.finish` event, but no such event exists according to the [official NodeJS documentation](https://nodejs.org/api/net.html#net_class_net_socket). There is one called `socket.end` though, lets use that one.

We can close #227 after merging this PR.

Closes #403