### PR TITLE
Use properly constructed URI in RTSP PLAY command

### DIFF
--- a/lib/components/rtsp-session/index.test.ts
+++ b/lib/components/rtsp-session/index.test.ts
@@ -72,6 +72,7 @@ describe('session', () => {
       const uri = 'rtsp://whatever/path'
       const s = new RtspSession({ uri })
       s.outgoing.once('data', (req) => {
+        console.log('DATA', req)
         expect(req.uri).toEqual(uri)
         done()
       })

--- a/lib/components/rtsp-session/index.ts
+++ b/lib/components/rtsp-session/index.ts
@@ -366,6 +366,7 @@ export class RtspSession extends Tube {
         headers: {
           Range: `npt=${this.startTime || 0}-`,
         },
+        uri: this._contentBase ? this._contentBase : this.uri,
       })
     }
     this._dequeue()
@@ -391,6 +392,7 @@ export class RtspSession extends Tube {
         headers: {
           Session: this._sessionId,
         },
+        uri: this._contentBase ? this._contentBase : this.uri,
       })
     }
     this._state = STATE.PLAYING

--- a/lib/utils/protocols/rtsp.ts
+++ b/lib/utils/protocols/rtsp.ts
@@ -114,6 +114,13 @@ export const contentBase = (buffer: Buffer) => {
   return extractHeaderValue(buffer, 'Content-Base')
 }
 
+export const contentLocation = (buffer: Buffer) => {
+  /**
+   * Content-Location   =  "Content-Location" HCOLON RTSP-REQ-Ref
+   */
+  return extractHeaderValue(buffer, 'Content-Location')
+}
+
 export const connectionEnded = (buffer: Buffer) => {
   /**
    * Connection         =  "Connection" HCOLON connection-token


### PR DESCRIPTION
Improve how the control URL is constructed, follow RFC. See #306 for more information.