### PR TITLE
Prevent process exit on parse error

### DIFF
--- a/lib/components/rtsp-parser/index.ts
+++ b/lib/components/rtsp-parser/index.ts
@@ -24,8 +24,12 @@ export class RtspParser extends Tube {
       objectMode: true,
       transform: function (msg: Message, encoding, callback) {
         if (msg.type === MessageType.RAW) {
-          parser.parse(msg.data).forEach((message) => incoming.push(message))
-          callback()
+          try {
+            parser.parse(msg.data).forEach((message) => incoming.push(message))
+            callback()
+          } catch (e) {
+            callback(e)
+          }
         } else {
           // Not a message we should handle
           callback(undefined, msg)


### PR DESCRIPTION
We're using media-stream-library in our node project and we unfortunately experience hard process.exits if the rtsp client tries to setup a connection to a device/server that's not able to serve rtsp, but instead responds with 404 for example.

This fix prevents this crash and instead propagates the error up the pipeline.