### PR TITLE
feat!: expose browser by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,9 @@
   "version": "8.0.4",
   "description": "Media stream library for Node & the Web.",
   "license": "MIT",
-  "main": "dist/cjs/index.node.js",
-  "browser": "dist/esm/index.browser.js",
+  "main": "dist/media-stream-library.min.js",
+  "types": "dist/esm/index.browser.d.ts",
   "browserslist": "last 2 versions, not dead",
-  "module": "dist/esm/index.node.js",
   "bin": {
     "live": "examples/node/player.js"
   },


### PR DESCRIPTION
Trying to have default entry points for both
node and browser seems to be a bit of a mess
to have it work properly for all kinds of
environments.

Instead, only browser entry points are exposed,
with the `browser` field pointing to the bundle
(so you don't need to be able to bundle the
browserify parts yourself when using this).

If using with Node.js, you'll have to import
from `dist/cjs/index.node.js` directly.