### PR TITLE
chore: use debug print to report appendBuffer problems

### DIFF
--- a/lib/components/mse/index.ts
+++ b/lib/components/mse/index.ts
@@ -76,7 +76,7 @@ export class MseSink extends Sink {
               try {
                 sourceBuffer.appendBuffer(msg.data)
               } catch (err) {
-                console.error('failed to append to SourceBuffer: ', err, msg)
+                debug('failed to append to SourceBuffer: ', err, msg)
               }
             }
             mse.addEventListener('sourceopen', handler)
@@ -90,7 +90,7 @@ export class MseSink extends Sink {
             try {
               sourceBuffer.appendBuffer(msg.data)
             } catch (e) {
-              console.error('failed to append to SourceBuffer: ', e, msg)
+              debug('failed to append to SourceBuffer: ', e, msg)
             }
           }
         } else if (msg.type === MessageType.RTCP) {


### PR DESCRIPTION
It can happen that appendBuffer fails because the
video element was already removed. To avoid unnecessary
error logs in those cases, replace those with a debug
log instead. The error was not reported on the stream
anyway, so it's only really useful for debugging
purposes.