### PR TITLE
feat: use HTTP headers from streaming MP4

### DIFF
--- a/lib/components/message.ts
+++ b/lib/components/message.ts
@@ -65,6 +65,7 @@ export interface IsomMessage extends GenericMessage {
   readonly type: MessageType.ISOM
   readonly checkpointTime?: number // presentation time of last I-frame (s)
   readonly tracks?: MediaTrack[]
+  readonly mime?: string
 }
 
 export interface XmlMessage extends GenericMessage {

--- a/lib/pipelines/http-mse-pipeline.ts
+++ b/lib/pipelines/http-mse-pipeline.ts
@@ -1,7 +1,6 @@
 import { Pipeline } from './pipeline'
-import { HttpSource, HttpConfig } from '../components/http-source'
+import { HttpMp4Source, HttpConfig } from '../components/http-mp4'
 import { MseSink } from '../components/mse'
-import { Mp4Parser } from '../components/mp4-parser'
 
 export interface HttpMseConfig {
   http: HttpConfig
@@ -15,19 +14,23 @@ export interface HttpMseConfig {
  * that is then sent to a HTML video element
  */
 export class HttpMsePipeline extends Pipeline {
-  public http: HttpSource
+  public onHeaders?: (headers: Headers) => void
+  public http: HttpMp4Source
 
-  private readonly _src?: HttpSource
+  private readonly _src?: HttpMp4Source
   private readonly _sink: MseSink
 
   constructor(config: HttpMseConfig) {
     const { http: httpConfig, mediaElement } = config
 
-    const httpSource = new HttpSource(httpConfig)
-    const mp4Parser = new Mp4Parser()
+    const httpSource = new HttpMp4Source(httpConfig)
     const mseSink = new MseSink(mediaElement)
 
-    super(httpSource, mp4Parser, mseSink)
+    httpSource.onHeaders = (headers) => {
+      this.onHeaders && this.onHeaders(headers)
+    }
+
+    super(httpSource, mseSink)
 
     this._src = httpSource
     this._sink = mseSink


### PR DESCRIPTION
We need to set the content type from the response headers of streaming
MP4 on the media source.  This is implemented as a separate component
(as it only works for MP4 data over HTTP), while the original HTTP
source component remains unchanged (for any kind of data).

The HttpMsePipeline now uses the new HttpMp4 source and therefore skips
the MP4 parser component completely. There should be no noticeable
change when using that pipeline, other than not being able to get access
to separate boxes.

Additionally, expose all headers on both HTTP sources to users (via
component and pipeline onHeaders callback).

BREAKING CHANGE: no longer possible to access ISOM boxes on the
HttpMsePipeline (if you used this, then you need to construct the
old pipeline yourself).