### PR TITLE
Non monotonic stream produce negative sample duration and RangeError:…

### DIFF
--- a/lib/components/mp4muxer/helpers/boxbuilder.ts
+++ b/lib/components/mp4muxer/helpers/boxbuilder.ts
@@ -217,12 +217,9 @@ export class BoxBuilder {
     // The RTP timestamps are unsigned 32 bit and will overflow
     // at some point. We can guard against the overflow by ORing with 0,
     // which will bring any difference back into signed 32-bit domain.
-    const duration =
-      trackData.lastTimestamp !== 0
-        ? (timestamp - trackData.lastTimestamp) | 0
-        : trackData.defaultFrameDuration
-
-    trackData.lastTimestamp = timestamp
+    const _duration = trackData.lastTimestamp !== 0 ? timestamp - trackData.lastTimestamp | 0 : trackData.defaultFrameDuration;
+    const duration = _duration > 0 ? _duration : trackData.defaultFrameDuration;
+    trackData.lastTimestamp = _duration > 0 ? timestamp : (trackData.lastTimestamp + duration);
 
     const moof = new Container('moof')
     const traf = new Container('traf')


### PR DESCRIPTION
… "value" argument is out of bounds
Example stream: rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov often produce this error in the audio track.
Fallback to track default frame duration if the timestamp is not monotonic inside the stream.
Not sure it is a proper/correct fix, but the stream is at least playable instead of the error.