### PR TITLE
fix: stop rtsp session when closing pipeline

### DIFF
--- a/.yarn/versions/9f7df4a4.yml
+++ b/.yarn/versions/9f7df4a4.yml
@@ -1,0 +1,2 @@
+releases:
+  media-stream-library: patch

--- a/lib/pipelines/html5-canvas-pipeline.ts
+++ b/lib/pipelines/html5-canvas-pipeline.ts
@@ -72,6 +72,7 @@ export class Html5CanvasPipeline extends RtspMjpegPipeline {
   }
 
   close() {
+    this.rtsp.stop()
     this._src && this._src.outgoing.end()
   }
 

--- a/lib/pipelines/html5-video-pipeline.ts
+++ b/lib/pipelines/html5-video-pipeline.ts
@@ -69,6 +69,7 @@ export class Html5VideoPipeline extends RtspMp4Pipeline {
   }
 
   close() {
+    this.rtsp.stop()
     this._src && this._src.outgoing.end()
   }
 


### PR DESCRIPTION
Sends a TEARDOWN message to invalidate
the rtsp session.

### Describe your changes

Our client never sends the TEARDOWN message when stopping

### Issue ticket number and link

- Fixes #687 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
