### PR TITLE
chore: install just in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
     if: ${{ startsWith(github.event.head_commit.message, 'release:') }}
     runs-on: ubuntu-latest
     steps:
+      - uses: extractions/setup-just@v1
       - uses: actions/checkout@v3
         with:
           lfs: true


### PR DESCRIPTION
Just is needed  to build.