### PR TITLE
chore: add fallback package exports

### DIFF
--- a/overlay/package.json
+++ b/overlay/package.json
@@ -14,6 +14,9 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
   "exports": {
     "types": "./dist/index.d.ts",
     "require": "./dist/index.cjs",

--- a/player/package.json
+++ b/player/package.json
@@ -18,6 +18,9 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
   "exports": {
     "types": "./dist/index.d.ts",
     "require": "./dist/index.cjs",

--- a/scripts/changelog.mjs
+++ b/scripts/changelog.mjs
@@ -17,8 +17,10 @@ const ChangeLogHeader = `# Changelog
 
 All notable changes to this project will be documented in this file.
 `
-const GitHubCompareUrl = 'https://github.com/AxisCommunications/media-stream-library-js/compare'
-const GitHubCommitUrl = 'https://github.com/AxisCommunications/media-stream-library-js/commit'
+const GitHubCompareUrl =
+  'https://github.com/AxisCommunications/media-stream-library-js/compare'
+const GitHubCommitUrl =
+  'https://github.com/AxisCommunications/media-stream-library-js/commit'
 const GroupTitles = {
   'build': '\u{1F477} Build',
   'chore': '\u{1F6A7} Maintenance',

--- a/streams/package.json
+++ b/streams/package.json
@@ -16,6 +16,9 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
+  "types": "./dist/src/index.browser.d.ts",
+  "main": "./dist/node.cjs",
+  "module": "./dist/node.mjs",
   "exports": {
     "types": "./dist/src/index.browser.d.ts",
     "browser": {
@@ -30,6 +33,8 @@
     }
   },
   "browser": {
+    "./dist/node.cjs": "./dist/browser.cjs",
+    "./dist/node.mjs": "./dist/browser.mjs",
     "stream": "stream-browserify"
   },
   "files": [


### PR DESCRIPTION
When using TypeScript the exports field is not
working unless using moduleResolution node16,
which we don't want to enforce.

Instead, fallbacks are added back so that these
projects can still use moduleResolution node.