### PR TITLE
feat: export modules that include dependencies

### DIFF
--- a/player/README.md
+++ b/player/README.md
@@ -122,18 +122,24 @@ npm install media-stream-player
 You will also need to install a number of peer dependencies
 such as [luxon](https://github.com/moment/luxon), which we use for date and time purposes,
 `react`/`react-dom`, `styled-components`, and `media-stream-library`.
-You can find an example of this under `examples/react-app`.
+You can find an example of this under `example-player-react`, e.g.:
+
+```js
+import { BasicPlayer } from 'media-stream-player'
+```
+
+By default, we do not pre-bundle external dependencies. If this causes problems
+with certain bundlers (e.g. CRA), you can use a pre-bundled version like so:
+
+```js
+import { BasicPlayer } from 'media-stream-player/heavy'
+```
 
 To run our example react app, you can start a vite dev server with:
 
 ```sh
-export MSP_CAMERA=<YOUR_CAMERA_HOST>
-```
-
-for example
-
-```sh
 export MSP_CAMERA=http://192.168.0.90
+node vite.mjs
 ```
 
 where you specify the IP of the camera you want to proxy as the `MSP_CAMERA`

--- a/player/esbuild.mjs
+++ b/player/esbuild.mjs
@@ -10,17 +10,21 @@ if (!existsSync(buildDir)) {
   mkdirSync(buildDir)
 }
 
+const bundles = [
+  { format: 'esm', name: 'index.mjs', external: ['media-stream-library'] },
+  { format: 'cjs', name: 'index.cjs', external: ['media-stream-library'] },
+  { format: 'esm', name: 'index-heavy.mjs', external: [] },
+  { format: 'cjs', name: 'index-heavy.cjs', external: [] },
+]
+
 for (
-  const output of [
-    { format: 'esm', ext: 'mjs' },
-    { format: 'cjs', ext: 'cjs' },
-  ]
+  const { name, format, external } of bundles
 ) {
   buildSync({
     platform: 'browser',
     entryPoints: ['src/index.ts'],
-    outfile: join(buildDir, `index.${output.ext}`),
-    format: output.format,
+    outfile: join(buildDir, name),
+    format,
     external: [
       '@juggle/resize-observer',
       'debug',
@@ -28,11 +32,11 @@ for (
       'react',
       'react-dom',
       'luxon',
-      'media-stream-library',
       'styled-components',
+      ...external,
     ],
     bundle: true,
-    minify: true,
+    minify: false,
     sourcemap: true,
     // avoid a list of browser targets by setting a common baseline ES level
     target: 'es2015',

--- a/player/package.json
+++ b/player/package.json
@@ -22,9 +22,16 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "require": "./dist/index.cjs",
-    "import": "./dist/index.mjs"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.mjs"
+    },
+    "./heavy": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index-heavy.cjs",
+      "import": "./dist/index-heavy.mjs"
+    }
   },
   "files": [
     "dist/**/*",

--- a/streams/README.md
+++ b/streams/README.md
@@ -77,11 +77,18 @@ import {components, pipelines} from 'media-stream-library';
 
 Note that we expose entry points for both node and the browser. Any bundler
 should be able to pick up the correct entry point from `package.json`. If not,
-then you can try importing from `media-stream-library/dist/browser-esm`
-instead. Since we no longer pre-bundle external dependencies, your bundler will
-have to handle this. It might be that you need to replace references to
-`global` with `window` because `readable-streams` (imported via
-`stream-browserify`) still refers to `global`.
+then you can try importing from `media-stream-library/dist/browser` instead.
+
+It might be that you need to replace references to `global` with `window`
+because `readable-streams` (imported via `stream-browserify`) still refers to
+`global`.
+
+By default, we do not pre-bundle external dependencies. If this causes problems
+with certain bundlers (e.g. CRA), you can use a pre-bundled version like so:
+
+```js
+import {components, pipelines} from 'media-stream-library/heavy';
+```
 
 ### Components and pipelines
 

--- a/streams/esbuild.mjs
+++ b/streams/esbuild.mjs
@@ -10,36 +10,53 @@ if (!existsSync(buildDir)) {
   mkdirSync(buildDir)
 }
 
-for (
-  const output of [
-    { format: 'esm', ext: 'mjs' },
-    { format: 'cjs', ext: 'cjs' },
-  ]
-) {
+const browserBundles = [
+  {
+    format: 'esm',
+    name: 'browser.mjs',
+    external: ['stream', 'buffer', 'process'],
+  },
+  {
+    format: 'cjs',
+    name: 'browser.cjs',
+    external: ['stream', 'buffer', 'process'],
+  },
+  { format: 'esm', name: 'browser-heavy.mjs' },
+  { format: 'cjs', name: 'browser-heavy.cjs' },
+]
+
+for (const { format, name, external } of browserBundles) {
   buildSync({
     platform: 'browser',
     entryPoints: ['src/index.browser.ts'],
-    outfile: join(buildDir, `browser.${output.ext}`),
-    format: output.format,
+    outfile: join(buildDir, name),
+    format,
     // Needed because readable-streams (needed by stream-browserify) still references global.
     // There are issues on this, but they get closed, so unsure if this will ever change.
     define: {
       global: 'window',
     },
     inject: ['polyfill.mjs'],
-    external: ['stream', 'buffer', 'process'],
+    external,
     bundle: true,
     minify: false,
     sourcemap: true,
     // avoid a list of browser targets by setting a common baseline ES level
     target: 'es2015',
   })
+}
 
+const nodeBundles = [
+  { format: 'esm', name: 'node.mjs' },
+  { format: 'cjs', name: 'node.cjs' },
+]
+
+for (const { format, name } of nodeBundles) {
   buildSync({
     platform: 'node',
     entryPoints: ['src/index.node.ts'],
-    outfile: join(buildDir, `node.${output.ext}`),
-    format: output.format,
+    outfile: join(buildDir, name),
+    format,
     external: ['stream', 'buffer', 'process', 'ws'],
     bundle: true,
     minify: false,

--- a/streams/package.json
+++ b/streams/package.json
@@ -20,16 +20,23 @@
   "main": "./dist/node.cjs",
   "module": "./dist/node.mjs",
   "exports": {
-    "types": "./dist/src/index.browser.d.ts",
-    "browser": {
+    ".": {
       "types": "./dist/src/index.browser.d.ts",
-      "require": "./dist/browser.cjs",
-      "import": "./dist/browser.mjs"
+      "browser": {
+        "types": "./dist/src/index.browser.d.ts",
+        "require": "./dist/browser.cjs",
+        "import": "./dist/browser.mjs"
+      },
+      "node": {
+        "types": "./dist/src/index.node.d.ts",
+        "require": "./dist/node.cjs",
+        "import": "./dist/node.mjs"
+      }
     },
-    "node": {
-      "types": "./dist/src/index.node.d.ts",
-      "require": "./dist/node.cjs",
-      "import": "./dist/node.mjs"
+    "./heavy": {
+      "types": "./dist/src/index.browser.d.ts",
+      "require": "./dist/browser-heavy.cjs",
+      "import": "./dist/browser-heavy.mjs"
     }
   },
   "browser": {


### PR DESCRIPTION
Some dependencies are difficult to handle by external bundlers, especially the node deps replaced for the browser.

In that case, we can allow to e.g.:

```
import { ... } from 'media-stream-player/heavy'
```

which already includes those dependencies.
Not everything is bundled though.

Fixes #743