### PR TITLE
fix!: bundle stream-browserify/process by default

### DIFF
--- a/overlay/esbuild.mjs
+++ b/overlay/esbuild.mjs
@@ -36,11 +36,6 @@ buildSync({
   outfile: join(buildDir, 'media-overlay-library.min.js'),
   format: 'iife',
   globalName: 'mediaOverlayLibrary',
-  // Needed because readable-streams (needed by stream-browserify) still references global.
-  // There are issues on this, but they get closed, so unsure if this will ever change.
-  define: {
-    global: 'window',
-  },
   bundle: true,
   minify: true,
   sourcemap: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3056,6 +3056,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5265,6 +5266,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -6386,6 +6388,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6502,7 +6505,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ini": {
       "version": "2.0.0",
@@ -9874,6 +9878,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -10259,6 +10264,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10678,6 +10684,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
       "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dev": true,
       "dependencies": {
         "inherits": "~2.0.4",
         "readable-stream": "^3.5.0"
@@ -10687,6 +10694,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -11681,7 +11689,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/util-extend": {
       "version": "1.0.3",
@@ -12742,7 +12751,7 @@
       },
       "peerDependencies": {
         "luxon": "^3.0.0",
-        "media-stream-library": "^12.2.0",
+        "media-stream-library": "^13.0.0",
         "react": "^17.0.2 || ^18.1.0",
         "react-dom": "^17.0.2 || ^18.1.0",
         "styled-components": "^5.3.5"
@@ -12765,11 +12774,8 @@
       "version": "12.3.0",
       "license": "MIT",
       "dependencies": {
-        "buffer": "6.0.3",
         "debug": "4.3.4",
-        "events": "3.3.0",
         "process": "0.11.10",
-        "stream-browserify": "3.0.0",
         "ts-md5": "1.3.1",
         "ws": "8.14.2"
       },
@@ -12777,11 +12783,14 @@
         "@types/debug": "4.1.9",
         "@types/node": "18.17.17",
         "@types/ws": "8.5.5",
+        "buffer": "6.0.3",
         "esbuild": "0.19.3",
+        "events": "3.3.0",
         "global-jsdom": "9.1.0",
         "jsdom": "21.1.2",
         "mock-socket": "9.3.1",
         "semver": "7.5.4",
+        "stream-browserify": "3.0.0",
         "typescript": "5.2.2",
         "uvu": "0.5.6"
       }
@@ -12796,6 +12805,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/player/README.md
+++ b/player/README.md
@@ -128,11 +128,17 @@ You can find an example of this under `example-player-react`, e.g.:
 import { BasicPlayer } from 'media-stream-player'
 ```
 
-By default, we do not pre-bundle external dependencies. If this causes problems
-with certain bundlers (e.g. CRA), you can use a pre-bundled version like so:
+There have been issue where bundlers pick up the wrong variant of `media-stream-player`,
+in which case you can try to override the resolution with an alias that points directly
+at the `browser` variant (and not the `node`) variant, e.g.:
 
 ```js
-import { BasicPlayer } from 'media-stream-player/heavy'
+{
+  //configuration options
+  alias: {
+    "media-stream-library": "media-stream-library/dist/browser"
+  }
+}
 ```
 
 To run our example react app, you can start a vite dev server with:

--- a/player/esbuild.mjs
+++ b/player/esbuild.mjs
@@ -11,14 +11,12 @@ if (!existsSync(buildDir)) {
 }
 
 const bundles = [
-  { format: 'esm', name: 'index.mjs', external: ['media-stream-library'] },
-  { format: 'cjs', name: 'index.cjs', external: ['media-stream-library'] },
-  { format: 'esm', name: 'index-heavy.mjs', external: [] },
-  { format: 'cjs', name: 'index-heavy.cjs', external: [] },
+  { format: 'esm', name: 'index.mjs' },
+  { format: 'cjs', name: 'index.cjs' },
 ]
 
 for (
-  const { name, format, external } of bundles
+  const { name, format } of bundles
 ) {
   buildSync({
     platform: 'browser',
@@ -33,7 +31,7 @@ for (
       'react-dom',
       'luxon',
       'styled-components',
-      ...external,
+      'media-stream-library',
     ],
     bundle: true,
     minify: false,
@@ -49,11 +47,6 @@ buildSync({
   outfile: join(buildDir, 'media-stream-player.min.js'),
   format: 'iife',
   globalName: 'mediaStreamPlayer',
-  // Needed because readable-streams (needed by stream-browserify) still references global.
-  // There are issues on this, but they get closed, so unsure if this will ever change.
-  define: {
-    global: 'window',
-  },
   bundle: true,
   minify: true,
   sourcemap: true,

--- a/player/package.json
+++ b/player/package.json
@@ -26,11 +26,6 @@
       "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.mjs"
-    },
-    "./heavy": {
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index-heavy.cjs",
-      "import": "./dist/index-heavy.mjs"
     }
   },
   "files": [
@@ -45,7 +40,7 @@
   },
   "peerDependencies": {
     "luxon": "^3.0.0",
-    "media-stream-library": "^12.2.0",
+    "media-stream-library": "^13.0.0",
     "react": "^17.0.2 || ^18.1.0",
     "react-dom": "^17.0.2 || ^18.1.0",
     "styled-components": "^5.3.5"

--- a/streams/README.md
+++ b/streams/README.md
@@ -79,16 +79,19 @@ Note that we expose entry points for both node and the browser. Any bundler
 should be able to pick up the correct entry point from `package.json`. If not,
 then you can try importing from `media-stream-library/dist/browser` instead.
 
-It might be that you need to replace references to `global` with `window`
-because `readable-streams` (imported via `stream-browserify`) still refers to
-`global`.
-
-By default, we do not pre-bundle external dependencies. If this causes problems
-with certain bundlers (e.g. CRA), you can use a pre-bundled version like so:
+**Note** By default, we pre-bundle some external dependencies that are
+particularly annoying to deal with. If you use these separately in your own
+code and want to avoid bundling them twice, you can use the "light" version to
+handle all bundling yourself:
 
 ```js
-import {components, pipelines} from 'media-stream-library/heavy';
+import {components, pipelines} from 'media-stream-library/light';
 ```
+
+It might be that you need to replace references to `global` with `window`
+because `readable-streams` (imported via `stream-browserify`) still refers to
+`global`. You'll also need polyfills for `Buffer` and `process`. You can check
+the `streams/esbuild.mjs` script for how we bundle.
 
 ### Components and pipelines
 

--- a/streams/esbuild.mjs
+++ b/streams/esbuild.mjs
@@ -14,29 +14,40 @@ const browserBundles = [
   {
     format: 'esm',
     name: 'browser.mjs',
-    external: ['stream', 'buffer', 'process'],
+    external: ['debug', 'ts-md5', 'ws'],
+    inject: ['polyfill.mjs'],
   },
   {
     format: 'cjs',
     name: 'browser.cjs',
-    external: ['stream', 'buffer', 'process'],
+    external: ['debug', 'ts-md5', 'ws'],
+    inject: ['polyfill.mjs'],
   },
-  { format: 'esm', name: 'browser-heavy.mjs' },
-  { format: 'cjs', name: 'browser-heavy.cjs' },
+  {
+    format: 'esm',
+    name: 'browser-light.mjs',
+    external: ['buffer', 'debug', 'process', 'stream', 'ts-md5', 'ws'],
+  },
+  {
+    format: 'cjs',
+    name: 'browser-light.cjs',
+    external: ['buffer', 'debug', 'process', 'stream', 'ts-md5', 'ws'],
+  },
 ]
 
-for (const { format, name, external } of browserBundles) {
+for (const { format, name, external, inject } of browserBundles) {
   buildSync({
     platform: 'browser',
     entryPoints: ['src/index.browser.ts'],
     outfile: join(buildDir, name),
     format,
-    // Needed because readable-streams (needed by stream-browserify) still references global.
+    // Needed because readable-stream (needed by stream-browserify) still references global.
     // There are issues on this, but they get closed, so unsure if this will ever change.
     define: {
       global: 'window',
+      process: 'process_browser',
     },
-    inject: ['polyfill.mjs'],
+    inject,
     external,
     bundle: true,
     minify: false,
@@ -71,10 +82,11 @@ buildSync({
   outfile: join(buildDir, 'media-stream-library.min.js'),
   format: 'iife',
   globalName: 'mediaStreamLibrary',
-  // Needed because readable-streams (needed by stream-browserify) still references global.
+  // Needed because readable-stream (needed by stream-browserify) still references global.
   // There are issues on this, but they get closed, so unsure if this will ever change.
   define: {
     global: 'window',
+    process: 'process_browser',
   },
   inject: ['polyfill.mjs'],
   bundle: true,

--- a/streams/package.json
+++ b/streams/package.json
@@ -33,10 +33,10 @@
         "import": "./dist/node.mjs"
       }
     },
-    "./heavy": {
+    "./light": {
       "types": "./dist/src/index.browser.d.ts",
-      "require": "./dist/browser-heavy.cjs",
-      "import": "./dist/browser-heavy.mjs"
+      "require": "./dist/browser-light.cjs",
+      "import": "./dist/browser-light.mjs"
     }
   },
   "browser": {
@@ -50,11 +50,8 @@
     "README.md"
   ],
   "dependencies": {
-    "buffer": "6.0.3",
     "debug": "4.3.4",
-    "events": "3.3.0",
     "process": "0.11.10",
-    "stream-browserify": "3.0.0",
     "ts-md5": "1.3.1",
     "ws": "8.14.2"
   },
@@ -62,11 +59,14 @@
     "@types/debug": "4.1.9",
     "@types/node": "18.17.17",
     "@types/ws": "8.5.5",
+    "buffer": "6.0.3",
     "esbuild": "0.19.3",
+    "events": "3.3.0",
     "global-jsdom": "9.1.0",
     "jsdom": "21.1.2",
     "mock-socket": "9.3.1",
     "semver": "7.5.4",
+    "stream-browserify": "3.0.0",
     "typescript": "5.2.2",
     "uvu": "0.5.6"
   }

--- a/streams/polyfill.mjs
+++ b/streams/polyfill.mjs
@@ -1,4 +1,4 @@
 import { Buffer } from 'buffer'
 window.Buffer = Buffer
-import * as process from 'process/browser'
-window.process = process
+import * as process_browser from 'process/browser'
+window.process_browser = process_browser


### PR DESCRIPTION
Ever since the change away from automatically bundling browser-equivalents of `Buffer` and `stream` Node.js dependencies, there have been a number of issues with bundling. Since this is such a problem, the proposal is to fix it by including the bundle as default, prioritizing ease-of-use over bundle size.

The bundle size in most cases won't be affected however, so this change should go mostly unnoticed except for people using their own bundler (vite, CRA, webpack, etc) having less headaches.

For those very special use-cases where it's adamant to bundle manually, there is a "light" version of `media-stream-library` where you need to deal with the bundling yourself.

Fixes #754