### PR TITLE
feat(player): add support for /mjpg/video.mjpg

### DIFF
--- a/player/src/PlaybackArea.tsx
+++ b/player/src/PlaybackArea.tsx
@@ -33,6 +33,7 @@ export enum AxisApi {
   'AXIS_IMAGE_CGI' = 'AXIS_IMAGE_CGI',
   'AXIS_MEDIA_AMP' = 'AXIS_MEDIA_AMP',
   'AXIS_MEDIA_CGI' = 'AXIS_MEDIA_CGI',
+  'AXIS_MJPEG_CGI' = 'AXIS_MJPEG_CGI',
 }
 
 export enum Protocol {
@@ -45,6 +46,7 @@ export enum Protocol {
 export const FORMAT_API: Record<Format, AxisApi> = {
   RTP_H264: AxisApi.AXIS_MEDIA_AMP,
   RTP_JPEG: AxisApi.AXIS_MEDIA_AMP,
+  MJPEG: AxisApi.AXIS_MJPEG_CGI,
   MP4_H264: AxisApi.AXIS_MEDIA_CGI,
   JPEG: AxisApi.AXIS_IMAGE_CGI,
 }
@@ -117,6 +119,16 @@ const imgUri = (
 ) => {
   return host.length !== 0
     ? `${protocol}//${host}/axis-cgi/jpg/image.cgi?${searchParams}`
+    : ''
+}
+
+const mjpegUri = (
+  protocol: Protocol.HTTP | Protocol.HTTPS,
+  host: string,
+  searchParams: string
+) => {
+  return host.length !== 0
+    ? `${protocol}//${host}/mjpg/video.mjpg?${searchParams}`
     : ''
 }
 
@@ -194,6 +206,29 @@ const PARAMETERS: Record<AxisApi, ReadonlyArray<string>> = {
     'event',
     'timestamp',
     'videocodec',
+  ],
+  [AxisApi.AXIS_MJPEG_CGI]: [
+    'camera',
+    'resolution',
+    'streamprofile',
+    'compression',
+    'colorlevel',
+    'color',
+    'palette',
+    'clock',
+    'date',
+    'text',
+    'textstring',
+    'textcolor',
+    'textbackgroundcolor',
+    'rotation',
+    'textpos',
+    'overlayimage',
+    'overlaypos',
+    'duration',
+    'nbrofframes',
+    'fps',
+    'timestamp',
   ],
 }
 
@@ -306,6 +341,25 @@ export const PlaybackArea: React.FC<PlaybackAreaProps> = ({
     )
   }
 
+  if (format === Format.MJPEG) {
+    const src = mjpegUri(
+      secure ? Protocol.HTTPS : Protocol.HTTP,
+      host,
+      searchParams(FORMAT_API[format], {
+        ...parameters,
+        timestamp,
+      })
+    )
+
+    return (
+      <StillImage
+        key={refresh}
+        forwardedRef={forwardedRef as Ref<HTMLImageElement>}
+        {...{ src, play, onPlaying }}
+      />
+    )
+  }
+
   if (format === Format.MP4_H264) {
     const src = mediaUri(
       secure ? Protocol.HTTPS : Protocol.HTTP,
@@ -327,12 +381,13 @@ export const PlaybackArea: React.FC<PlaybackAreaProps> = ({
     )
   }
 
-  console.warn(`Error: unknown format: ${format},
+  console.warn(`Error: unknown format: ${format}, 
 please use one of ${
     [
-      Format.RTP_H264,
       Format.JPEG,
+      Format.MJPEG,
       Format.MP4_H264,
+      Format.RTP_H264,
       Format.RTP_JPEG,
     ].join(', ')
   }`)

--- a/player/src/Stats.tsx
+++ b/player/src/Stats.tsx
@@ -138,6 +138,8 @@ const StatsData: React.FC<
     let streamType = 'Unknown'
     if (format === Format.JPEG) {
       streamType = 'Still image'
+    } else if (format === Format.MJPEG) {
+      streamType = 'MJPEG'
     } else if (format === Format.RTP_H264) {
       streamType = 'RTSP (WebSocket)'
     } else if (format === Format.RTP_JPEG) {
@@ -167,7 +169,7 @@ const StatsData: React.FC<
       )
       const videoTrack = tracks?.find((track) => track.type === 'video')
       if (videoTrack !== undefined) {
-        const { coding, profile, level } = videoTrack?.codec
+        const { coding, profile, level } = videoTrack.codec
         const framerate = Number(
           pipeline.framerate[videoTrack.index].toFixed(2)
         )

--- a/player/src/StillImage.tsx
+++ b/player/src/StillImage.tsx
@@ -27,7 +27,6 @@ interface StillImageProps {
  * Properties:
  *
  * play: indicated the _intended_ playback state
- * ws/rtsp: src URIs for WebSocket/RTP server
  *
  * Internal state:
  * canplay: there is enough data on the video element to play

--- a/player/src/constants.ts
+++ b/player/src/constants.ts
@@ -5,4 +5,5 @@ export const FORMAT_SUPPORTS_AUDIO: Record<Format, boolean> = {
   RTP_JPEG: false,
   MP4_H264: true,
   JPEG: false,
+  MJPEG: false,
 }

--- a/player/src/types.ts
+++ b/player/src/types.ts
@@ -2,5 +2,6 @@ export enum Format {
   'RTP_H264' = 'RTP_H264',
   'RTP_JPEG' = 'RTP_JPEG',
   'JPEG' = 'JPEG',
+  'MJPEG' = 'MJPEG',
   'MP4_H264' = 'MP4_H264',
 }

--- a/player/src/utils/browserSupportedFormats.ts
+++ b/player/src/utils/browserSupportedFormats.ts
@@ -25,5 +25,6 @@ export const browserSupportedFormats: Record<Format, boolean> = {
   [Format.RTP_H264]: isH264Supported() && MSE_SUPPORT,
   [Format.RTP_JPEG]: isMJPEGSupported(),
   [Format.JPEG]: true,
+  [Format.MJPEG]: isMJPEGSupported(),
   [Format.MP4_H264]: isH264Supported(),
 }


### PR DESCRIPTION
### Describe your changes

A more basic endpoint for mjpeg exists in /mjpg/video.mjpg. This is basically a multipart stream of never ending jpeg images, which are delivered using "best effort".

### Issue ticket number and link

- Fixes #811

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
