### PR TITLE
Add webRTC video

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -10,7 +10,9 @@
   },
   "json": {},
   "dockerfile": {},
-  "includes": ["**/*.{ts,tsx,cjs,mjs,json}"],
+  "includes": [
+    "**/*.{ts,tsx,jsx,cjs,mjs,json}"
+  ],
   "excludes": [
     "**/dist",
     "**/buildinfo*.json",

--- a/example-player-react/App.jsx
+++ b/example-player-react/App.jsx
@@ -5,6 +5,7 @@ import styled, { createGlobalStyle } from 'styled-components'
 import { BasicStream } from './BasicStream'
 import { MultiStream } from './MultiStream'
 import { SingleStream } from './SingleStream'
+import { WebRtcStream } from './WebRtcStream'
 
 const GlobalStyle = createGlobalStyle`
   body {
@@ -48,6 +49,11 @@ export const App = () => {
     localStorage.setItem(LOCALSTORAGE_KEY, 'basic')
   }, [setState])
 
+  const webrtc = useCallback(() => {
+    setState('webrtc')
+    localStorage.setItem(LOCALSTORAGE_KEY, 'webrtc')
+  }, [setState])
+
   const multi = useCallback(() => {
     setState('multi')
     localStorage.setItem(LOCALSTORAGE_KEY, 'multi')
@@ -67,10 +73,14 @@ export const App = () => {
         <Button onClick={multi} selected={state === 'multi'}>
           Multi stream
         </Button>
+        <Button onClick={webrtc} selected={state === 'webrtc'}>
+          webRTC stream
+        </Button>
       </ButtonContainer>
       {state === 'single' ? <SingleStream /> : null}
       {state === 'basic' ? <BasicStream /> : null}
       {state === 'multi' ? <MultiStream /> : null}
+      {state === 'webrtc' ? <WebRtcStream /> : null}
     </AppContainer>
   )
 }

--- a/example-player-react/App.jsx
+++ b/example-player-react/App.jsx
@@ -29,8 +29,7 @@ const ButtonContainer = styled.div`
 const Button = styled.button`
   padding: 8px 12px;
   margin: 4px;
-  background-color: ${({ selected }) =>
-    selected ? 'lightgreen' : 'lightpink'};
+  background-color: ${({ selected }) => selected ? 'lightgreen' : 'lightpink'};
 `
 
 const LOCALSTORAGE_KEY = 'media-stream-player-example'

--- a/example-player-react/MultiStream.jsx
+++ b/example-player-react/MultiStream.jsx
@@ -70,29 +70,31 @@ export const MultiStream = () => {
 
   return (
     <>
-      {state.length > 0 ? (
-        state.map((device) => {
-          return device.authorized ? (
-            <MediaPlayerContainer key={device.hostname}>
-              <Centered>{device.hostname}</Centered>
-              <MediaPlayer
-                hostname={device.hostname}
-                initialFormat="JPEG"
-                autoPlay
-                autoRetry
-                vapixParams={{ resolution: '800x600' }}
-              />
-            </MediaPlayerContainer>
-          ) : (
-            <MediaPlayerContainer key={device.hostname}>
-              <Centered>{device.hostname}</Centered>
-              <Centered>Not authorized</Centered>
-            </MediaPlayerContainer>
-          )
-        })
-      ) : (
-        <div>No authorized devices</div>
-      )}
+      {state.length > 0
+        ? (
+          state.map((device) => {
+            return device.authorized
+              ? (
+                <MediaPlayerContainer key={device.hostname}>
+                  <Centered>{device.hostname}</Centered>
+                  <MediaPlayer
+                    hostname={device.hostname}
+                    initialFormat="JPEG"
+                    autoPlay
+                    autoRetry
+                    vapixParams={{ resolution: '800x600' }}
+                  />
+                </MediaPlayerContainer>
+              )
+              : (
+                <MediaPlayerContainer key={device.hostname}>
+                  <Centered>{device.hostname}</Centered>
+                  <Centered>Not authorized</Centered>
+                </MediaPlayerContainer>
+              )
+          })
+        )
+        : <div>No authorized devices</div>}
     </>
   )
 }

--- a/example-player-react/WebRtcStream.jsx
+++ b/example-player-react/WebRtcStream.jsx
@@ -1,0 +1,195 @@
+import React, { useCallback, useMemo, useState } from 'react'
+
+import styled from 'styled-components'
+
+import { BasicPlayer } from 'media-stream-player'
+
+const Wrapper = styled.div`
+  display: grid;
+  width: 100%;
+  grid-auto-flow: row;
+  grid-template-rows: min-content auto;
+  grid-gap: 32px;
+  justify-content: center;
+`
+
+const StyledForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`
+
+const PlayerContainer = styled.div`
+  height: 400px;
+  width: 700px;
+`
+
+const convertSearchParams = (searchParams) => {
+  const params = searchParams.split('&')
+
+  return params.reduce((acc, param) => {
+    const [key, value] = param.split('=')
+    if (value === '') {
+      return acc
+    }
+    return {
+      ...acc,
+      [key]: value,
+    }
+  }, {})
+}
+
+/**
+ * Example application that uses web RTC streaming and the `BasicPlayer` component.
+ */
+export const WebRtcStream = () => {
+  const [refresh, setRefresh] = useState(0)
+
+  const [formValues, setFormValues] = useState(() => {
+    const web_rtc_creds_storage = localStorage.getItem('webrtc_creds')
+    if (web_rtc_creds_storage !== null) {
+      return JSON.parse(web_rtc_creds_storage)
+    }
+
+    return {
+      organizationArn: '',
+      serial: '',
+      env: 'stage',
+      token: '',
+      params: '',
+    }
+  })
+
+  const [creds, setCreds] = useState(null)
+
+  const handleSubmit = useCallback((ev) => {
+    ev.preventDefault()
+
+    localStorage.setItem('webrtc_creds', JSON.stringify(formValues))
+
+    setCreds(formValues)
+    setRefresh(previousValue => previousValue + 1)
+  }, [formValues, setCreds, setRefresh])
+
+  const handleChange = useCallback((ev) => {
+    ev.preventDefault()
+    const nextFormValues = {}
+    const nextValue = ev.target.value.trim()
+    nextFormValues[ev.target.id] = nextValue
+
+    setCreds(null)
+    setFormValues((previousValue) => ({ ...previousValue, ...nextFormValues }))
+  }, [setCreds, setFormValues])
+
+  // web RTC signaling requires a promise that returns a token
+  const authenticator = useCallback(() => {
+    return new Promise(resolve => {
+      resolve(creds?.token)
+    })
+  }, [creds?.token])
+
+  // The signaling options is configuration
+  // for web RTC streaming.
+  const signalingOptions = useMemo(() => {
+    if (creds === null) {
+      return
+    }
+    const { token, params, ...rest } = creds
+    const invalidCreds = Object.values(rest).some(value => value === '')
+    if (invalidCreds) {
+      return undefined
+    }
+    return {
+      ...rest,
+      authenticator,
+    }
+  }, [authenticator, creds])
+
+  const vapixParams = useMemo(() => {
+    if (formValues.params === '') {
+      return undefined
+    }
+
+    return convertSearchParams(formValues.params)
+  }, [formValues])
+
+  return (
+    <Wrapper>
+      <StyledForm
+        onSubmit={handleSubmit}
+      >
+        <label htmlFor="organizationArn">Organization arn</label>
+        <input
+          id="organizationArn"
+          type="text"
+          placeholder="00000000-0000-0000-0000-000000000000"
+          value={formValues.organizationArn}
+          onChange={handleChange}
+        />
+
+        <label htmlFor="serial">Device S/N</label>
+        <input
+          id="serial"
+          type="text"
+          placeholder="AA11BB22BB33"
+          value={formValues.serial}
+          onChange={handleChange}
+        />
+
+        <label htmlFor="token">Bearer token</label>
+        <textarea
+          id="token"
+          placeholder="xxx-xxx-xxx-xxx"
+          value={formValues.token}
+          onChange={handleChange}
+        />
+
+        <label htmlFor="env">Environment</label>
+        <select
+          id="env"
+          value={formValues.env}
+          onChange={handleChange}
+        >
+          <option value="stage">stage</option>
+          <option value="prod">prod</option>
+        </select>
+
+        <label htmlFor="params">
+          Stream parameters (supported: width, height, channel, framerate)
+        </label>
+        <textarea
+          id="params"
+          type="text"
+          placeholder="key=value&key=value"
+          value={formValues.params}
+          onChange={handleChange}
+        />
+        {vapixParams !== undefined && (
+          <>
+            <pre>Params sent to the webRTC session</pre>
+            <pre>{JSON.stringify(vapixParams, null, 2)}</pre>
+          </>
+        )}
+
+        <button style={{ width: '150px', alignSelf: 'center' }} type="submit">
+          Submit
+        </button>
+      </StyledForm>
+      {creds !== null && (
+        <PlayerContainer>
+          <BasicPlayer
+            hostname={window.location.host}
+            format="WEBRTC"
+            autoPlay
+            autoRetry
+            refresh={refresh}
+            {...(signalingOptions !== undefined ? { signalingOptions } : {})}
+            {...(creds.params !== undefined
+              ? { vapixParams: convertSearchParams(creds.params) }
+              : {})}
+          />
+        </PlayerContainer>
+      )}
+    </Wrapper>
+  )
+}

--- a/player/README.md
+++ b/player/README.md
@@ -31,6 +31,7 @@ we make underlying API-calls to AXIS specfic APIs to get the video streams.
 
 - For H.264 to work you need at least firmware 6.50 (LTS)
 - For MP4 to work you need at least firmware 9.80 (LTS)
+- For webRTC to work you need to have webRTC installed on the device.
 
 ## Structure
 
@@ -61,10 +62,10 @@ Then, you can use the `<media-stream-player/>` tag, similar to how you would use
 
 You can find an example of this under `example-player-webcomponent`.
 
-Supported properties right now are:
+Supported properties right now, with exceptions for webRTC, are:
 
-| Property              | Comment                                                                            |
-| --------------------- | ---------------------------------------------------------------------------------- |
+| Property              | Comment                                                                            | webRTC
+| --------------------- | ---------------------------------------------------------------------------------- | ------
 | `variant`             | Supported choices are `basic` or `advanced`. Refers to `BasicPlayer` and `Player`. |
 | `hostname`            | The ip address to your device                                                      |
 | `autoplay`            | If the property exists, we try and autoplay your video                             |
@@ -72,12 +73,12 @@ Supported properties right now are:
 | `secure`              | If the property exists, we will connect with https instead of http                 |
 | `format`              | Accepted values are `JPEG`, `RTP_JPEG`, `RTP_H264`, or `MP4_H264`                  |
 | `compression`         | Accepted values are `0..100`, with 10 between each step                            |
-| `resolution`          | Written as WidthXHeight, eg `1920x1080`                                            |
-| `rotation`            | Accepted values are `0`, `90`, `180` and `270`                                     |
-| `camera`              | Accepted values are `0...n` or `quad` depending on your device                     |
+| `resolution`          | Written as WidthXHeight, eg `1920x1080`                                            | yes
+| `rotation`            | Accepted values are `0`, `90`, `180` and `270`                                     | yes
+| `camera`              | Accepted values are `0...n` or `quad` depending on your device                     | yes
 |                       | **RTP_H264 / RTP_JPEG / MP4_H264 specific properties**                             |
-| `fps`                 | Accepted values are `0...n`                                                        |
-| `audio`               | Accepted values are `0` (off) and `1` (on)                                         |
+| `fps`                 | Accepted values are `0...n`                                                        | yes
+| `audio`               | Accepted values are `0` (off) and `1` (on)                                         | requested by default
 | `clock`               | Accepted values are `0` (hide) and `1` (show)                                      |
 | `date`                | Accepted values are `0` (hide) and `1` (show)                                      |
 | `text`                | Accepted values are `0` (hide text overlay) and `1` (show text overlay)            |
@@ -85,6 +86,10 @@ Supported properties right now are:
 | `textcolor`           | Accepted values are `black` and `white`                                            |
 | `textbackgroundcolor` | Accepted values are `black`, `white`, `transparent` and `semitransparent`          |
 | `textpos`             | Accepted values are `0` (top) and `1` (bottom)                                     |
+| `videomaxbitrate`     | Accepted values are `0...n`                                                        | yes      
+| `videozstrength`      | Accepted values are `off`,`10`,`20`,`30`,`40`,`50`                                 | yes
+| `videozgopmode`       | Accepted values are `dynamic` or `fixed`                                           | yes
+| `streamprofile`       | Acceted value, `string`                                                            | yes
 
 Example:
 
@@ -162,6 +167,7 @@ value). You can also debug a specific component by using one of the following fr
 | ----- |
 | `msp:http-mp4-video` |
 | `msp:ws-rtsp-video` |
+| `msp:webrtc-video` |
 | `msp:still-image` |
 | `msp:api` |
 

--- a/player/src/BasicPlayer.tsx
+++ b/player/src/BasicPlayer.tsx
@@ -22,6 +22,7 @@ import {
   VideoProperties,
 } from './PlaybackArea'
 import { Format } from './types'
+import { SignalingOptions } from './WebRtcVideo'
 
 const DEFAULT_FORMAT = Format.JPEG
 
@@ -40,6 +41,8 @@ interface BasicPlayerProps {
    * Activate automatic retries on RTSP errors.
    */
   readonly autoRetry?: boolean
+  readonly signalingOptions?: SignalingOptions
+  readonly refresh?: number
 }
 
 export const BasicPlayer = forwardRef<PlayerNativeElement, BasicPlayerProps>(
@@ -52,6 +55,8 @@ export const BasicPlayer = forwardRef<PlayerNativeElement, BasicPlayerProps>(
       autoRetry = false,
       secure,
       className,
+      signalingOptions,
+      refresh,
     },
     ref
   ) => {
@@ -145,7 +150,6 @@ export const BasicPlayer = forwardRef<PlayerNativeElement, BasicPlayerProps>(
      * aspect ratio is carried over to the container, and the layers match the
      * container size.
      */
-
     return (
       <MediaStreamPlayerContainer className={className}>
         <Limiter ref={limiterRef}>
@@ -153,7 +157,7 @@ export const BasicPlayer = forwardRef<PlayerNativeElement, BasicPlayerProps>(
             <Layer>
               <PlaybackArea
                 forwardedRef={ref}
-                refresh={0}
+                refresh={refresh ?? 0}
                 play={play}
                 host={host}
                 format={format}
@@ -161,6 +165,7 @@ export const BasicPlayer = forwardRef<PlayerNativeElement, BasicPlayerProps>(
                 onPlaying={onPlaying}
                 secure={secure}
                 autoRetry={autoRetry}
+                signalingOptions={signalingOptions}
               />
             </Layer>
             <Layer>

--- a/player/src/WebRtcVideo.tsx
+++ b/player/src/WebRtcVideo.tsx
@@ -1,0 +1,158 @@
+import React, { Ref, useEffect, useRef } from 'react'
+
+import debug from 'debug'
+import styled from 'styled-components'
+
+import { FORMAT_SUPPORTS_AUDIO } from './constants'
+import { useEventState } from './hooks/useEventState'
+import { VapixParameters, VideoProperties } from './PlaybackArea'
+import { Format } from './types'
+import { Session } from './webrtc/Session'
+import { Authenticator } from './webrtc/types'
+import { vapixParameterToVideoReceive } from './webrtc/vapixParameterToVideoReceive'
+
+const debugLog = debug('msp:webrtc-video')
+
+const VideoNative = styled.video`
+  max-height: 100%;
+  object-fit: contain;
+  width: 100%;
+`
+
+export interface SignalingOptions {
+  readonly authenticator: Authenticator
+  readonly env: 'stage' | 'prod'
+  readonly organizationArn: string
+  readonly serial: string
+}
+
+interface WebRtcVideoProps {
+  readonly forwardedRef?: Ref<HTMLVideoElement>
+  /**
+   * The _intended_ playback state.
+   */
+  readonly play?: boolean
+
+  /**
+   * WebRTC options
+   */
+  readonly signalingOptions: SignalingOptions
+
+  readonly parameters: VapixParameters
+
+  /**
+   * Activate automatic playback.
+   */
+  readonly autoPlay?: boolean
+  /**
+   * Default mute state.
+   */
+  readonly muted?: boolean
+  /**
+   * Callback to signal video is playing.
+   */
+  readonly onPlaying?: (videoProperties: VideoProperties) => void
+  /**
+   * Callback to signal video ended.
+   */
+  readonly onEnded?: () => void
+}
+
+export const WebRtcVideo: React.FC<WebRtcVideoProps> = ({
+  forwardedRef,
+  muted,
+  autoPlay,
+  onPlaying,
+  play,
+  signalingOptions,
+  parameters,
+}: WebRtcVideoProps) => {
+  let videoRef = useRef<HTMLVideoElement>(null)
+
+  // Forwarded refs can either be a callback or the result of useRef
+  if (typeof forwardedRef === 'function') {
+    forwardedRef(videoRef.current)
+  } else if (forwardedRef) {
+    videoRef = forwardedRef
+  }
+
+  // keep a stable reference to the external onPlaying callback
+  const __onPlayingRef = useRef(onPlaying)
+  __onPlayingRef.current = onPlaying
+
+  /**
+   * Internal state:
+   * -> canplay: there is enough data on the video element to play.
+   * -> playing: the video element playback is progressing.
+   */
+  const [canplay, unsetCanplay] = useEventState(videoRef, 'canplay')
+  const [playing, unsetPlaying] = useEventState(videoRef, 'playing')
+
+  useEffect(() => {
+    const videoEl = videoRef.current
+
+    if (videoEl === null) {
+      return
+    }
+
+    if (play && canplay && !playing) {
+      debugLog('play')
+      videoEl.play().catch((err) => {
+        console.error('VideoElement error: ', err.message)
+      })
+
+      const { videoHeight, videoWidth } = videoEl
+      debugLog('%o', {
+        videoHeight,
+        videoWidth,
+      })
+    } else if (!play && playing) {
+      debugLog('pause')
+      videoEl.pause()
+      unsetPlaying()
+    } else if (play && playing) {
+      if (__onPlayingRef.current !== undefined) {
+        __onPlayingRef.current({
+          el: videoEl,
+          width: videoEl.videoWidth,
+          height: videoEl.videoHeight,
+          formatSupportsAudio: FORMAT_SUPPORTS_AUDIO[Format.WEBRTC],
+          volume: videoEl.volume,
+        })
+      }
+    }
+  }, [play, canplay, playing, unsetPlaying])
+
+  useEffect(() => {
+    const node = videoRef.current
+    const params = vapixParameterToVideoReceive(parameters)
+
+    const session = new Session(
+      signalingOptions.authenticator,
+      signalingOptions.organizationArn,
+      signalingOptions.serial,
+      params,
+      {
+        onTrack(streams) {
+          if (node !== null) {
+            node.srcObject = streams[0]
+          }
+        },
+      },
+      signalingOptions.env
+    )
+
+    session.init()
+
+    return () => {
+      session.close()
+      if (node !== null) {
+        node.src = ''
+      }
+      unsetCanplay()
+      unsetPlaying()
+    }
+  }, [parameters, signalingOptions, unsetCanplay, unsetPlaying])
+
+  return <VideoNative autoPlay={autoPlay} muted={muted} ref={videoRef} />
+}

--- a/player/src/constants.ts
+++ b/player/src/constants.ts
@@ -6,4 +6,5 @@ export const FORMAT_SUPPORTS_AUDIO: Record<Format, boolean> = {
   MP4_H264: true,
   JPEG: false,
   MJPEG: false,
+  WEBRTC: true,
 }

--- a/player/src/types.ts
+++ b/player/src/types.ts
@@ -4,4 +4,5 @@ export enum Format {
   'JPEG' = 'JPEG',
   'MJPEG' = 'MJPEG',
   'MP4_H264' = 'MP4_H264',
+  'WEBRTC' = 'WEBRTC',
 }

--- a/player/src/utils/browserSupportedFormats.ts
+++ b/player/src/utils/browserSupportedFormats.ts
@@ -27,4 +27,5 @@ export const browserSupportedFormats: Record<Format, boolean> = {
   [Format.JPEG]: true,
   [Format.MJPEG]: isMJPEGSupported(),
   [Format.MP4_H264]: isH264Supported(),
+  [Format.WEBRTC]: window.RTCPeerConnection !== undefined,
 }

--- a/player/src/webrtc/Session.ts
+++ b/player/src/webrtc/Session.ts
@@ -1,0 +1,155 @@
+import debug from 'debug'
+
+import { Signaling, SignalingListener } from './Signaling'
+import {
+  Authenticator,
+  Environment,
+  SessionListener,
+  WebRTCVideoReceive,
+} from './types'
+
+const debugLog = debug('msp:webrtc-video')
+
+export class Session {
+  authenticator: Authenticator
+  organizationArn: string
+  targetId: string
+  options: WebRTCVideoReceive
+  env: Environment
+  peerConnection: RTCPeerConnection
+  signaling?: Signaling
+  listener: SessionListener
+  sessionId: string
+
+  constructor(
+    authenticator: Authenticator,
+    organizationArn: string,
+    targetId: string,
+    options: WebRTCVideoReceive,
+    listener: SessionListener,
+    env: Environment = 'prod'
+  ) {
+    this.sessionId = crypto.randomUUID()
+    this.authenticator = authenticator
+    this.organizationArn = organizationArn
+    this.targetId = targetId
+    this.options = options
+    this.listener = listener
+    this.env = env
+    this.peerConnection = new RTCPeerConnection()
+  }
+
+  init() {
+    this.peerConnection.onconnectionstatechange = () => {
+      debugLog('connections state change', this.peerConnection.connectionState)
+
+      if (this.peerConnection.connectionState === 'disconnected') {
+        debugLog(
+          'PeerConnection.onconnectionstatechange',
+          'disconnected',
+          this.peerConnection
+        )
+        // Try to reconnect
+        if (this.signaling === undefined) {
+          debugLog(
+            'PeerConnection.onconnectionstatechange',
+            'disconnected',
+            'Trying to reconnect but signaling is undefined'
+          )
+        }
+        this.signaling?.connect().catch(console.trace)
+      }
+
+      if (this.peerConnection.connectionState === 'failed') {
+        debugLog(
+          'PeerConnection.onconnectionstatechange',
+          'failed',
+          this.peerConnection
+        )
+      }
+
+      if (this.peerConnection.connectionState === 'connected') {
+        debugLog(
+          'PeerConnection.onconnectionstatechange',
+          'connected',
+          this.peerConnection
+        )
+      }
+    }
+
+    this.peerConnection.onicecandidate = (ev) => {
+      debugLog('PeerConnection.onicecandidate', ev)
+      if (ev.candidate !== null) {
+        this.signaling?.sendLocalIceCandidate(ev.candidate).catch(console.trace)
+      }
+    }
+
+    this.peerConnection.ontrack = (ev) => {
+      debugLog('PeerConnection.ontrack', ev)
+      this.listener.onTrack(ev.streams)
+    }
+
+    const listeners: SignalingListener = {
+      onIceServers: (iceServers: Array<RTCIceServer>) => {
+        this.peerConnection.setConfiguration({ iceServers })
+      },
+
+      onRemoteSessionDescription: (
+        signaling: Signaling,
+        sessionDescription: RTCSessionDescriptionInit
+      ) =>
+        (async () => {
+          if (this.peerConnection === undefined) {
+            return
+          }
+
+          await this.peerConnection.setRemoteDescription(sessionDescription)
+          const localSessionDescription: RTCSessionDescriptionInit = await this
+            .peerConnection.createAnswer()
+          await this.peerConnection.setLocalDescription(
+            localSessionDescription
+          )
+
+          signaling.sendLocalDescription(localSessionDescription).catch(
+            console.trace
+          )
+        })(),
+
+      onError: (
+        errorCode: string,
+        errorDescription: string
+      ) => debugLog('SignalingListener.onError', errorCode, errorDescription),
+
+      onRemoteIceCandidate: (
+        iceCandidate: RTCIceCandidateInit
+      ) => {
+        if (this.peerConnection === undefined) {
+          debugLog(
+            'SignalingListener.onRemoteIceCandiate',
+            'peerConnection not yet initialized'
+          )
+          return
+        }
+
+        this.peerConnection.addIceCandidate(iceCandidate).catch(console.trace)
+      },
+    }
+
+    this.signaling = new Signaling(
+      this.authenticator,
+      this.organizationArn.replace('arn:organization:', ''),
+      this.targetId,
+      this.options,
+      listeners,
+      this.env
+    )
+
+    this.signaling.connect().catch(console.trace)
+  }
+
+  close() {
+    debugLog('Session.close', this.sessionId)
+    this.signaling?.disconnect()
+    this.peerConnection?.close()
+  }
+}

--- a/player/src/webrtc/Signaling.ts
+++ b/player/src/webrtc/Signaling.ts
@@ -1,0 +1,227 @@
+import debug from 'debug'
+
+import {
+  Authenticator,
+  Environment,
+  IceSignalingMessage,
+  InitSessionMessage,
+  Message,
+  SDPSignalingMessage,
+  WebRTCVideoReceive,
+} from './types'
+
+const debugLog = debug('msp:webrtc-video')
+
+export interface SignalingListener {
+  onIceServers: (iceServers: Array<RTCIceServer>) => void
+  onRemoteIceCandidate: (
+    iceCandidate: RTCIceCandidateInit
+  ) => void
+  onRemoteSessionDescription: (
+    signaling: Signaling,
+    sessionDescription: RTCSessionDescriptionInit
+  ) => void
+  onError: (
+    errorCode: string,
+    errorDescription: string
+  ) => void
+}
+
+export class Signaling {
+  sessionId = ''
+  authenticator: Authenticator
+  organizationArn: string
+  targetId: string
+  env: Environment
+  options: WebRTCVideoReceive
+  listener: SignalingListener
+  ws?: WebSocket
+
+  constructor(
+    authenticator: Authenticator,
+    organizationArn: string,
+    targetId: string,
+    options: WebRTCVideoReceive,
+    listener: SignalingListener,
+    env: Environment = 'prod'
+  ) {
+    this.sessionId = crypto.randomUUID()
+    this.authenticator = authenticator
+    this.organizationArn = organizationArn
+    this.targetId = targetId
+    this.env = env
+    this.options = options
+    this.listener = listener
+  }
+
+  async connect() {
+    if (this.ws !== undefined) {
+      this.ws.close(1000, 're-initializing connection')
+    }
+
+    const baseUrl = `wss://signaling.${this.env}.webrtc.connect.axis.com/client`
+    const bearer = encodeURIComponent(await this.authenticator())
+    const url = `${baseUrl}?authorization=${bearer}`
+
+    debugLog('Signaling.connect', `${baseUrl}?authorization=***`)
+
+    this.ws = new WebSocket(url)
+
+    this.ws.onerror = (ev) => {
+      debugLog('wss.onerror', ev)
+    }
+
+    this.ws.onopen = () => {
+      // Being polite
+      this.send({
+        type: 'hello',
+      })
+    }
+
+    this.ws.onmessage = (e) => {
+      const msg: Message = JSON.parse(e.data.toString())
+      debugLog('Signaling.wss message', msg.type, e)
+      this.onMessage(msg).catch(console.trace)
+    }
+
+    this.ws.onclose = (ev) => {
+      debugLog('Signaling.wss websocket closed', ev.code, ev.reason)
+    }
+  }
+
+  disconnect() {
+    if (this.ws === undefined) {
+      debugLog(`Signaling websocket is undefined`)
+    }
+    this.ws?.close(1000, 'disconnect')
+  }
+
+  send(msg: Message) {
+    if (this.ws === undefined) {
+      debugLog(`Signaling websocket is undefined`)
+    }
+    this.ws?.send(JSON.stringify(msg))
+  }
+
+  async onMessage(msg: Message) {
+    switch (msg.type) {
+      // Device responds with hello
+      // We create a new message initSession
+      case 'hello': {
+        try {
+          const accessToken = await this.authenticator()
+          const initSessionMessage: InitSessionMessage = {
+            type: 'initSession',
+            accessToken,
+            orgId: this.organizationArn,
+            targetId: this.targetId,
+            data: {
+              apiVersion: '1.0',
+              method: 'initSession',
+              type: 'request',
+              sessionId: this.sessionId,
+              params: {
+                audioReceive: {},
+                type: 'live',
+                videoReceive: {
+                  ...this.options,
+                },
+              },
+            },
+          }
+          this.send(initSessionMessage)
+        } catch (e) {
+          console.error(e)
+        }
+
+        break
+      }
+      case 'error': {
+        debugLog('Signaling:onMessage.error', msg)
+        break
+      }
+      // Device responds to initSession
+      case 'initSession': {
+        const iceServers: Array<RTCIceServer> = []
+        if (msg.turnServers !== undefined) {
+          msg.turnServers.forEach((server) => {
+            iceServers.push({
+              urls: [...server.urls],
+              username: server.username,
+              credential: server.password,
+            })
+          })
+        }
+        if (msg.stunServers !== undefined) {
+          msg.stunServers.forEach((server) => {
+            iceServers.push({ urls: [...server.urls] })
+          })
+        }
+
+        this.listener.onIceServers(iceServers)
+        break
+      }
+      case 'signaling': {
+        if (msg.data.method === 'setSdpOffer' && msg.data.type === 'request') {
+          this.listener.onRemoteSessionDescription(this, msg.data.params)
+          return
+        }
+        if (
+          msg.data.method === 'addIceCandidate'
+          && msg.data.type === 'request'
+        ) {
+          this.listener.onRemoteIceCandidate(msg.data.params)
+          return
+        }
+        if (msg.data.type === 'response' && msg.data.error !== undefined) {
+          const { code, message } = msg.data.error
+          this.listener.onError(code, message)
+        }
+      }
+    }
+  }
+
+  async sendLocalIceCandidate(ic: RTCIceCandidate) {
+    try {
+      const accessToken = await this.authenticator()
+      const msg: IceSignalingMessage = {
+        type: 'signaling',
+        accessToken,
+        orgId: this.organizationArn,
+        targetId: this.targetId,
+        data: {
+          apiVersion: '1.0',
+          sessionId: this.sessionId,
+          method: 'addIceCandidate',
+          type: 'request',
+          params: ic,
+        },
+      }
+      this.send(msg)
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  async sendLocalDescription(sdp: RTCSessionDescriptionInit) {
+    try {
+      const accessToken = await this.authenticator()
+      const msg: SDPSignalingMessage = {
+        type: 'signaling',
+        accessToken,
+        orgId: this.organizationArn,
+        targetId: this.targetId,
+        data: {
+          apiVersion: '1.0',
+          sessionId: this.sessionId,
+          method: 'setSdpAnswer',
+          type: 'request',
+          params: sdp,
+        },
+      }
+      this.send(msg)
+    } catch (e) {
+      console.error(e)
+    }
+  }
+}

--- a/player/src/webrtc/types.ts
+++ b/player/src/webrtc/types.ts
@@ -1,0 +1,138 @@
+export type Authenticator = () => Promise<string>
+
+export type Environment = 'prod' | 'stage'
+
+export type Message =
+  | InitSessionMessage
+  | HelloMessage
+  | ErrorMessage
+  | SDPSignalingMessage
+  | IceSignalingMessage
+  | InitSessionSignalingMessage
+
+export interface ErrorMessage {
+  readonly type: 'error'
+  readonly correlationId?: string
+  readonly id?: string
+  readonly code?: string
+  readonly reason?: string
+}
+
+export interface WebRTCVideoReceive {
+  readonly width?: number
+  readonly height?: number
+  readonly channel?: number
+  readonly framerate?: number
+  readonly maxBitrateInKbps?: number
+  readonly zGopMode?: string // dynamic | fixed
+  readonly zStrength?: 'off' | number // 10, 20, 30, 40, 50
+  readonly rotation?: number // 0, 90, 180, 270
+  readonly streamProfile?: string
+}
+
+export interface InitSessionMessage {
+  readonly type: 'initSession'
+  readonly correlationId?: string
+  readonly id?: string
+  readonly orgId?: string
+  readonly targetId?: string
+  readonly accessToken?: string
+  readonly data: {
+    readonly apiVersion?: string
+    readonly method: 'initSession'
+    readonly type: 'request' | 'response'
+    readonly sessionId: string
+    readonly params: {
+      type: 'live'
+      readonly audioReceive?: Record<string, never>
+      readonly videoReceive: WebRTCVideoReceive
+    }
+  }
+  readonly turnServers?: ReadonlyArray<{
+    readonly urls: ReadonlyArray<string>
+    // valid for 10 minutes
+    readonly username: string
+    // valid for 10 minutes
+    readonly password: string
+  }>
+  readonly stunServers?: ReadonlyArray<{
+    readonly urls: Array<string>
+  }>
+}
+
+export interface HelloMessage {
+  readonly type: 'hello'
+  readonly correlationId?: string
+  readonly id?: string
+}
+
+export interface SDPSignalingMessage {
+  readonly type: 'signaling'
+  readonly correlationId?: string
+  readonly orgId?: string
+  readonly targetId?: string
+  readonly accessToken?: string
+  readonly data: {
+    readonly data?: unknown
+    readonly error?: {
+      readonly code: string
+      readonly message: string
+    }
+    readonly sessionId: string
+    readonly method: 'setSdpOffer' | 'setSdpAnswer'
+    readonly apiVersion?: string
+    readonly type: 'request' | 'response'
+    readonly params: {
+      readonly type: 'offer' | 'answer' | 'pranswer' | 'rollback'
+      readonly sdp?: string
+    }
+  }
+}
+
+export interface IceSignalingMessage {
+  readonly type: 'signaling'
+  readonly correlationId?: string
+  readonly orgId?: string
+  readonly targetId?: string
+  readonly accessToken?: string
+  readonly data: {
+    readonly data?: unknown
+    readonly error?: {
+      readonly code: string
+      readonly message: string
+    }
+    readonly sessionId: string
+    readonly method: 'addIceCandidate'
+    readonly apiVersion?: string
+    readonly type: 'request' | 'response'
+    readonly params: {
+      readonly candidate: string
+      readonly sdpMLineIndex: number | null
+      readonly sdpMid: string | null
+      readonly usernameFragment: string | null
+    }
+  }
+}
+
+export interface InitSessionSignalingMessage {
+  readonly type: 'signaling'
+  readonly correlationId?: string
+  readonly orgId?: string
+  readonly targetId?: string
+  readonly accessToken?: string
+  readonly data: {
+    readonly sessionId: string
+    readonly method: 'initSession'
+    readonly apiVersion?: string
+    readonly type: 'response'
+    readonly data?: unknown
+    readonly error?: {
+      readonly code: string
+      readonly message: string
+    }
+  }
+}
+
+export interface SessionListener {
+  onTrack: (streams: ReadonlyArray<MediaStream>) => void
+}

--- a/player/src/webrtc/vapixParameterToVideoReceive.ts
+++ b/player/src/webrtc/vapixParameterToVideoReceive.ts
@@ -1,0 +1,89 @@
+import { VapixParameters } from '../PlaybackArea'
+
+import { WebRTCVideoReceive } from './types'
+
+type OptionalVapixParameters = {
+  [Parameter in keyof VapixParameters]: Parameter | undefined
+}
+
+// Maps VAPIX parameters to webRTC videoRecieve parameters
+export const vapixParameterToVideoReceive = (
+  parameters: OptionalVapixParameters
+): WebRTCVideoReceive =>
+  Object.entries(parameters).reduce<WebRTCVideoReceive>(
+    (values, [key, value]) => {
+      if (value === undefined) {
+        return values
+      }
+
+      if (key === 'resolution') {
+        const [width, height] = value.split('x').map((v) => parseInt(v, 10))
+        return {
+          ...values,
+          width,
+          height,
+        }
+      }
+
+      if (key === 'camera') {
+        const channel = parseInt(value, 10)
+        return {
+          ...values,
+          channel,
+        }
+      }
+
+      if (key === 'fps') {
+        const framerate = parseInt(value, 10)
+        return {
+          ...values,
+          framerate,
+        }
+      }
+
+      if (key === 'videomaxbitrate') {
+        const maxBitrateInKbps = parseInt(value, 10)
+        return {
+          ...values,
+          maxBitrateInKbps,
+        }
+      }
+
+      if (key === 'videozgopmode') {
+        return {
+          ...values,
+          zGopMode: value,
+        }
+      }
+
+      if (key === 'videozstrength') {
+        let zStrength: Exclude<WebRTCVideoReceive['zStrength'], undefined> =
+          'off'
+        if (value !== 'off') {
+          zStrength = parseInt(value, 10)
+        }
+        return {
+          ...values,
+          zStrength,
+        }
+      }
+
+      if (key === 'rotation') {
+        const rotation = parseInt(value, 10)
+        return {
+          ...values,
+          rotation,
+        }
+      }
+
+      if (key === 'streamprofile') {
+        return {
+          ...values,
+          streamProfile: value,
+        }
+      }
+
+      return values
+    },
+    {}
+  )


### PR DESCRIPTION
<!--
Provide a general description of your change in the PR title.
Then:
- why: include a motivation + context
- what: summary of changes that were made
-->

- Devices can send video over webRTC and media-stream-library-js has to support this.
- Add webRTC connection by using browser RTCPeerConnection to a specific target
- Add currently supported parameters.
- Add easy example player with a form to input credentials. For ease of use, these credentials are stored in localStorage.

![image](https://github.com/AxisCommunications/media-stream-library-js/assets/77433590/30cff17c-6d9b-4c30-8737-91b0fdf5fbc4)

<!-- link related issues with e.g. Fixes #(issue) -->
