### PR TITLE
Add support for h264 signed code type 6 SEI

### DIFF
--- a/streams/src/components/h264depay/parser.ts
+++ b/streams/src/components/h264depay/parser.ts
@@ -7,6 +7,7 @@ export enum NAL_TYPES {
   UNSPECIFIED = 0,
   NON_IDR_PICTURE = 1, // P-frame
   IDR_PICTURE = 5, // I-frame
+  SEI_SIGNED_VIDEO = 6, // Axis Signed Video Framework
   SPS = 7,
   PPS = 8,
 }
@@ -92,7 +93,7 @@ export class H264DepayParser {
       }
       this._buffer = Buffer.alloc(0)
       return msg
-    } else if (type === 6)
+    } else if (type === NAL_TYPES.SEI_SIGNED_VIDEO)
     {
       const h264frame = Buffer.concat([
       Buffer.from([0, 0, 0, 0]),


### PR DESCRIPTION
<!--
Provide a general description of your change in the PR title.
- why: the video stream when enabled in the camera automatically includes the signed data/metadata
- what: added few lines of code to include the data in the video output
-->


<!-- Improvement #1061 -->

https://github.com/AxisCommunications/media-stream-library-js/issues/1061

Provide a general description of your change in the PR title:

- why: the video stream when enabled in the camera automatically includes the signed data/metadata
- what: added few lines of code to include the data in the video output

**Checklist for review**

- PR title and description are clear
- change follows existing coding style and architecture - yes
- necessary unit tests were added - not needed
- documentation was updated - tbd
