### PR TITLE
fix(streams): keepalive after rtcp bye

### DIFF
--- a/src/streams/components/rtsp/session.ts
+++ b/src/streams/components/rtsp/session.ts
@@ -12,6 +12,7 @@ import {
   RtspResponseMessage,
   Sdp,
   SdpMessage,
+  isRtcpBye,
   isRtcpSR,
 } from '../types'
 
@@ -113,6 +114,9 @@ export class RtspSession {
             }
             case 'rtcp': {
               this.recordNtpInfo(message)
+              if (isRtcpBye(message.rtcp)) {
+                this.clearKeepalive()
+              }
               this.onRtcp && this.onRtcp(message.rtcp)
               controller.enqueue(message)
               break


### PR DESCRIPTION
When a rtsp stream has ended, the keepalive continued to trigger. This caused an error in the console since the message could not be enqued.

<!--
Provide a general description of your change in the PR title.
Then:
- why: include a motivation + context
- what: summary of changes that were made
-->


<!-- link related issues with e.g. Fixes #(issue) -->

**Checklist for review**

- PR title and description are clear
- change follows existing coding style and architecture
- necessary unit tests were added
- documentation was updated
