### PR TITLE
fix(streams): handle rtcp bye with keepalive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 14.0.0-beta.7
+
+- Fix(streams): handle rtcp bye with keepalive
+
 ## 14.0.0-beta.6
 
 - Add license field to package.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "media-stream-library",
-  "version": "14.0.0-beta.6",
+  "version": "14.0.0-beta.7",
   "license": "MIT",
   "description": "Media libraries for Node and the Web.",
   "repository": {

--- a/src/streams/components/rtsp/session.ts
+++ b/src/streams/components/rtsp/session.ts
@@ -12,6 +12,7 @@ import {
   RtspResponseMessage,
   Sdp,
   SdpMessage,
+  isRtcpBye,
   isRtcpSR,
 } from '../types'
 
@@ -113,6 +114,9 @@ export class RtspSession {
             }
             case 'rtcp': {
               this.recordNtpInfo(message)
+              if (isRtcpBye(message.rtcp)) {
+                this.clearKeepalive()
+              }
               this.onRtcp && this.onRtcp(message.rtcp)
               controller.enqueue(message)
               break

--- a/src/streams/components/rtsp/session.ts
+++ b/src/streams/components/rtsp/session.ts
@@ -114,6 +114,9 @@ export class RtspSession {
             }
             case 'rtcp': {
               this.recordNtpInfo(message)
+              // FIXME it should be the responsibility of the user to call a `.close()` method
+              // on the instance to cleanup resources (this would also solve other problems
+              // related to not clearing the interval).
               if (isRtcpBye(message.rtcp)) {
                 this.clearKeepalive()
               }


### PR DESCRIPTION
When a rtsp stream has ended, the keepalive continued to trigger. This caused an error in the console since the message could not be enqueued.

<!--
Provide a general description of your change in the PR title.
Then:
- why: include a motivation + context
- what: summary of changes that were made
-->


<!-- link related issues with e.g. Fixes #(issue) -->

**Checklist for review**

- PR title and description are clear
- change follows existing coding style and architecture
- necessary unit tests were added
- documentation was updated
