### PR TITLE
feat(streams): add support for SEI NAL units

### DIFF
--- a/src/streams/components/rtp/h264-depay.ts
+++ b/src/streams/components/rtp/h264-depay.ts
@@ -13,6 +13,7 @@ export enum NAL_TYPES {
   UNSPECIFIED = 0,
   NON_IDR_PICTURE = 1, // P-frame
   IDR_PICTURE = 5, // I-frame
+  SEI = 6, // Supplemental Enhancement Information
   SPS = 7,
   PPS = 8,
 }
@@ -81,7 +82,8 @@ export class H264Depay {
       }
     } else if (
       (nalType === NAL_TYPES.NON_IDR_PICTURE ||
-        nalType === NAL_TYPES.IDR_PICTURE) &&
+        nalType === NAL_TYPES.IDR_PICTURE ||
+        nalType === NAL_TYPES.SEI) &&
       this.buffer.length === 0
     ) {
       /* Single NALU */ h264frame = concat([


### PR DESCRIPTION
Updates H.264 parser to handle NAL type 6 "SEI", carrying supplemental enhancement information, used e.g. for Axis [signed video framework](https://github.com/AxisCommunications/signed-video-framework/blob/master/README.md).

<!--
Provide a general description of your change in the PR title.
Then:
- why: include a motivation + context
- what: summary of changes that were made
-->


<!-- link related issues with e.g. Fixes #(issue) -->

**Checklist for review**

- PR title and description are clear
- change follows existing coding style and architecture
- necessary unit tests were added
- documentation was updated
