### PR TITLE
fix(streams): log abort as info

### DIFF
--- a/src/streams/components/mse-sink.ts
+++ b/src/streams/components/mse-sink.ts
@@ -1,4 +1,4 @@
-import { logDebug, logError, logInfo } from '../log'
+import { logDebug, logInfo } from '../log'
 
 import { IsomMessage } from './types'
 
@@ -71,7 +71,7 @@ export class MseSink {
         this.endOfStream()
       },
       abort: async (reason) => {
-        logError('media stream aborted:', reason)
+        logInfo('media stream aborted:', reason)
         this.endOfStream()
       },
     })


### PR DESCRIPTION
The severity when a stream is aborted was error, which is too high.

<!--
Provide a general description of your change in the PR title.
Then:
- why: include a motivation + context
- what: summary of changes that were made
-->


<!-- link related issues with e.g. Fixes #(issue) -->

**Checklist for review**

- PR title and description are clear
- change follows existing coding style and architecture
- necessary unit tests were added
- documentation was updated
