### PR TITLE
fix(streams): unable to enqueue when locked

### DIFF
--- a/src/streams/components/adapter.ts
+++ b/src/streams/components/adapter.ts
@@ -8,7 +8,9 @@ export class Adapter<T> extends TransformStream<Uint8Array> {
   constructor(generator: (chunk: Uint8Array) => T) {
     super({
       transform: (chunk, controller) => {
-        controller.enqueue(generator(chunk))
+        if (!this.writable.locked) {
+          controller.enqueue(generator(chunk))
+        }
       },
     })
   }

--- a/src/streams/components/ws-source.ts
+++ b/src/streams/components/ws-source.ts
@@ -32,7 +32,9 @@ export class WSSource {
         socket.addEventListener(
           'message',
           (e: MessageEvent<ArrayBufferLike>) => {
-            controller.enqueue(new Uint8Array(e.data))
+            if (!this.readable.locked) {
+              controller.enqueue(new Uint8Array(e.data))
+            }
           }
         )
         socket.addEventListener('close', (e) => {
@@ -59,7 +61,9 @@ export class WSSource {
       },
       write: (chunk) => {
         try {
-          socket.send(chunk)
+          if (!this.writable.locked) {
+            socket.send(chunk)
+          }
         } catch (err) {
           logWarn('message lost during send:', err)
         }


### PR DESCRIPTION
When the stream is closed for some reason, there will sometimes get new calls to the different methods, trying to enqueue a new package to the streams.

<!--
Provide a general description of your change in the PR title.
Then:
- why: include a motivation + context
- what: summary of changes that were made
-->


<!-- link related issues with e.g. Fixes #(issue) -->

**Checklist for review**

- PR title and description are clear
- change follows existing coding style and architecture
- necessary unit tests were added
- documentation was updated
